### PR TITLE
Add factories problem_factory and association_user_problem_factory

### DIFF
--- a/fake_data_factories/association_user_problem_factory.py
+++ b/fake_data_factories/association_user_problem_factory.py
@@ -1,0 +1,79 @@
+import asyncio
+from uuid import UUID
+
+from async_factory_boy.factory.sqlalchemy import AsyncSQLAlchemyFactory
+from sqlalchemy import func, select
+from termcolor import cprint
+
+from fake_data_factories.problem_factory import create_problems
+from src.database.sc_db_session import sc_session
+from src.problems.models.association_models import AssociationUserProblem
+
+
+class AssociationUserProblemFactory(AsyncSQLAlchemyFactory):
+    """
+    Фабрика генерации данных ассоциативной модели AssociationUserProblem.
+
+    Поля:
+        - id. Обязательное поле. \
+            Должно передаваться максимальное значение id в таблице + 1.
+        - left_id: Обязательное поле. Ссылка на пользователя Tabit. \
+            Должен быть создан объект UserTabit, чтобы передать полю id (типа uuid).
+        - right_id: Обязательное поле. Ссылка на проблему. \
+            Должен быть создан объект Problem, чтобы передать полю id.
+        - status: Обязательное поле. Значение по умолчанию - True.
+    """
+
+    id: int
+    left_id: UUID
+    right_id: int
+    status: bool = True
+
+    class Meta:
+        model = AssociationUserProblem
+        sqlalchemy_session = sc_session
+
+
+async def create_user_problem_associations(
+    user_id: UUID,
+    problem_ids: list[int],
+) -> None:
+    """
+    Создать запись в таблицу объекта AssociationUserProblem.
+
+    Поля:
+        - user_id: uuid пользователя Tabit;
+        - problem_ids: список id проблем.
+    """
+    for problem_id in problem_ids:
+        result = await sc_session.execute(select(func.max(AssociationUserProblem.id)))
+        new_id = (result.scalar() or 0) + 1
+        await AssociationUserProblemFactory.create(
+            id=new_id,
+            left_id=user_id,
+            right_id=problem_id,
+        )
+    cprint(
+        f'Создано {len(problem_ids)} ассоциативных связей проблема-пользователь '
+        f'от пользователя с id: {user_id}',
+        'green',
+    )
+
+
+async def main() -> None:
+    """
+    Запустить создание ассоциативных связей из модуля.
+
+    Примечание: запускается фабрика проблем, которая создаёт пользователя и пакет проблем
+    от его авторства.
+    """
+    user_tabit, problems = await create_problems()
+    problem_ids = [problem.id for problem in problems]
+    await create_user_problem_associations(
+        user_id=user_tabit.id,
+        problem_ids=problem_ids,
+    )
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/fake_data_factories/constants.py
+++ b/fake_data_factories/constants.py
@@ -3,6 +3,7 @@
 FAKER_USER_COUNT = 5  # Число пользователей для генерации
 FAKER_COMPANY_COUNT = 5  # Число компаний для генерации
 FAKER_DEPARTMENT_COUNT = 5  # Число отделов для генерации
+FAKER_PROBLEMS_COUNT: int = 5
 DEFAULT_DEPARTMENT_NAMES = [
     'Отдел кадров',
     'Отдел менеджмента',
@@ -16,3 +17,18 @@ LICENSE_TYPE_COUNT = 5
 DEFAULT_LICENSE_TERM = 365
 LICENSE_MAX_ADMINS = 100
 LICENSE_MAX_EMPLOYEES = 1000
+
+DEFAULT_PROBLEM_NAMES: list[str] = [
+    'Нехватка персонала',
+    'Медленный отклик на заявку',
+    'Несоблюдение делового стиля общения',
+    'Переносы сроков проектов',
+    'Неэффективные встречи',
+]
+DEFAULT_PROBLEM_DESCRIPTIONS: list[str | None] = [
+    None,
+    'Проблемы возникают на этапе взаимодействия с менеджерами.',
+    'Из проектов исчезло поле с дедлайном.',
+    'Слишком много времени тратится впустую.',
+    'Общение через почту слишком неэффективно.',
+]

--- a/fake_data_factories/fill_db.py
+++ b/fake_data_factories/fill_db.py
@@ -2,6 +2,7 @@ import asyncio
 
 from termcolor import colored, cprint
 
+from fake_data_factories.association_user_problem_factory import create_user_problem_associations
 from fake_data_factories.company_factories import create_companies
 from fake_data_factories.company_user_factories import create_company_users
 from fake_data_factories.constants import (
@@ -12,6 +13,7 @@ from fake_data_factories.constants import (
 )
 from fake_data_factories.department_factories import create_company_department
 from fake_data_factories.license_type_factories import create_license_type
+from fake_data_factories.problem_factory import create_problems
 from fake_data_factories.tabit_user_factories import create_tabit_admin_users
 
 
@@ -37,6 +39,12 @@ async def fill_all_data():
         await create_company_users(count=FAKER_USER_COUNT, company_id=company.id)
         await create_company_department(count=FAKER_DEPARTMENT_COUNT, company_id=company.id)
     await create_tabit_admin_users(count=FAKER_USER_COUNT)
+    user_tabit, problems = await create_problems()
+    problem_ids = [problem.id for problem in problems]
+    await create_user_problem_associations(
+        user_id=user_tabit.id,
+        problem_ids=problem_ids,
+    )
 
     cprint(
         colored('Генерация завершена!', 'red', attrs=['reverse', 'blink']),

--- a/fake_data_factories/problem_factory.py
+++ b/fake_data_factories/problem_factory.py
@@ -1,0 +1,84 @@
+import asyncio
+from random import choice
+from uuid import UUID
+
+import factory
+from async_factory_boy.factory.sqlalchemy import AsyncSQLAlchemyFactory
+from termcolor import cprint
+
+from fake_data_factories.company_factories import CompanyFactory
+from fake_data_factories.company_user_factories import CompanyUserFactory
+from fake_data_factories.constants import (
+    DEFAULT_PROBLEM_DESCRIPTIONS,
+    DEFAULT_PROBLEM_NAMES,
+    FAKER_PROBLEMS_COUNT,
+)
+from src.database.alembic_models import UserTabit
+from src.database.sc_db_session import sc_session
+from src.problems.models.enums import ColorProblem, StatusProblem, TypeProblem
+from src.problems.models.problem_models import Problem
+
+
+class ProblemFactory(AsyncSQLAlchemyFactory):
+    """
+    Фабрика генерации данных проблемы.
+
+    Поля:
+        - name: Обязательное поле. Генерируется случайным выбором из DEFAULT_PROBLEM_NAMES.
+        - description: Опциональное поле.\
+            Генерируется случайным выбором из DEFAULT_PROBLEM_DESCRIPTIONS.
+        - company_id: Обязательное поле. \
+            Должен быть создан объект Company, чтобы передать полю id.
+        - color: Обязательное поле. Генерируется случайным выбором из ColorProblem.
+        - type: Обязательное поле. Генерируется случайным выбором из TypeProblem.
+        - status: Обязательное поле. Генерируется случайным выбором из StatusProblem.
+        - owner_id: Обязательное поле. \
+            Должен быть создан объект UserTabit, чтобы передать полю id (типа uuid).
+    """
+
+    name: factory.LazyFunction = factory.LazyFunction(lambda: choice(DEFAULT_PROBLEM_NAMES))
+    description: factory.LazyFunction = factory.LazyFunction(
+        lambda: choice(DEFAULT_PROBLEM_DESCRIPTIONS)
+    )
+    company_id: int
+    color: factory.LazyFunction = factory.LazyFunction(lambda: choice(list(ColorProblem)))
+    type: factory.LazyFunction = factory.LazyFunction(lambda: choice(list(TypeProblem)))
+    status: factory.LazyFunction = factory.LazyFunction(lambda: choice(list(StatusProblem)))
+    owner_id: UUID
+
+    class Meta:
+        model = Problem
+        sqlalchemy_session = sc_session
+
+
+async def create_problems(
+    count: int = FAKER_PROBLEMS_COUNT, **kwargs
+) -> tuple[UserTabit, list[Problem]]:
+    """
+    Создать запись в таблицу объекта Problem.
+
+    Если функция запускается напрямую из текущего модуля, для этих проблем создаются:
+    - компания (id компании передаётся в фабрику);
+    - пользователь Tabit (uuid пользователя передаётся в фабрику).
+
+    Если функция запускается через импорт, в неё можно передать именованные аргументы:
+    - company_id (если не передать, запустится фабрика CompanyFactory);
+    - owner_id (если не передать, запустится фабрика CompanyUserFactory).
+    """
+    if 'company_id' not in kwargs:
+        company = await CompanyFactory.create()
+        kwargs['company_id'] = company.id
+    if 'owner_id' not in kwargs:
+        user_tabit = await CompanyUserFactory.create(company_id=kwargs['company_id'])
+        kwargs['owner_id'] = user_tabit.id
+    problems = await ProblemFactory.create_batch(count, **kwargs)
+    cprint(
+        f'Создано {count} проблем компании c id: {kwargs["company_id"]} '
+        f'от пользователя с id: {kwargs["owner_id"]}',
+        'green',
+    )
+    return user_tabit, problems
+
+
+if __name__ == '__main__':
+    asyncio.run(create_problems())

--- a/poetry.lock
+++ b/poetry.lock
@@ -671,13 +671,13 @@ sqlalchemy = {version = ">=2.0.0,<2.1.0", extras = ["asyncio"]}
 
 [[package]]
 name = "filelock"
-version = "3.17.0"
+version = "3.18.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338"},
-    {file = "filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e"},
+    {file = "filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"},
+    {file = "filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2"},
 ]
 
 [package.extras]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,7 +25,7 @@ fastapi-users-db-sqlalchemy==7.0.0 ; python_version >= "3.12" and python_version
 fastapi-users==14.0.1 ; python_version >= "3.12" and python_version < "4.0"
 fastapi-users[sqlalchemy]==14.0.1 ; python_version >= "3.12" and python_version < "4.0"
 fastapi==0.115.11 ; python_version >= "3.12" and python_version < "4.0"
-filelock==3.17.0 ; python_version >= "3.12" and python_version < "4.0"
+filelock==3.18.0 ; python_version >= "3.12" and python_version < "4.0"
 greenlet==3.1.1 ; python_version >= "3.12" and python_version < "4.0"
 h11==0.14.0 ; python_version >= "3.12" and python_version < "4.0"
 httpcore==1.0.7 ; python_version >= "3.12" and python_version < "4.0"


### PR DESCRIPTION
fixed #222 

Добавлены фабрики для создания проблем и ассоциативных связей **пользователь-проблема**.
Фабрики также запускаются через ```make fill-db```.

Примечание: помню, что в планах поменять ассоциативную таблицу (переименование полей **left_id** и **right_id**, а также избавление от **id**), но пока сделал по текущим реалиям.