### PR TITLE
add_admin_auth_in_swagger

### DIFF
--- a/src/api/v1/endpoints/tabit_admin_auth.py
+++ b/src/api/v1/endpoints/tabit_admin_auth.py
@@ -26,6 +26,7 @@ from src.api.v1.validator import (
     validator_check_not_is_superuser,
     validator_check_object_exists,
 )
+from src.constants import OPENAPI_EXTRA_ADMIN_AUTH
 from src.database.db_depends import get_async_session
 from src.tabit_management.crud import admin_crud
 from src.tabit_management.models import TabitAdminUser
@@ -40,7 +41,7 @@ router = APIRouter()
     dependencies=[Depends(current_superuser)],
     summary=Summary.TABIT_ADMIN_AUTH_LIST,
     description=Description.TABIT_ADMIN_AUTH_LIST,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def get_tabit_admin(
     session: AsyncSession = Depends(get_async_session),
@@ -65,7 +66,7 @@ async def get_tabit_admin(
     response_model=AdminReadSchema,
     summary=Summary.TABIT_ADMIN_AUTH_GET_ME,
     description=Description.TABIT_ADMIN_AUTH_GET_ME,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def get_me_tabit_admin(
     session: AsyncSession = Depends(get_async_session),
@@ -92,7 +93,7 @@ async def get_me_tabit_admin(
     response_model=AdminReadSchema,
     summary=Summary.TABIT_ADMIN_AUTH_PATCH_ME,
     description=Description.TABIT_ADMIN_AUTH_PATCH_ME,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def update_me_tabit_admin(
     user_in: AdminUpdateSchema,
@@ -122,7 +123,7 @@ async def update_me_tabit_admin(
     dependencies=[Depends(current_superuser)],
     summary=Summary.TABIT_ADMIN_AUTH_GET_BY_ID,
     description=Description.TABIT_ADMIN_AUTH_GET_BY_ID,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def get_tabit_admin_by_id(
     user_id: UUID,
@@ -150,7 +151,7 @@ async def get_tabit_admin_by_id(
     dependencies=[Depends(current_superuser)],
     summary=Summary.TABIT_ADMIN_AUTH_PATCH_BY_ID,
     description=Description.TABIT_ADMIN_AUTH_PATCH_BY_ID,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def update_tabit_admin_by_id(
     user_id: UUID,
@@ -186,7 +187,7 @@ async def update_tabit_admin_by_id(
     status_code=HTTPStatus.NO_CONTENT,
     summary=Summary.TABIT_ADMIN_AUTH_DELETE_BY_ID,
     description=Description.TABIT_ADMIN_AUTH_DELETE_BY_ID,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def delete_tabit_admin_by_id(
     user_id: UUID,
@@ -231,7 +232,7 @@ router.include_router(  # форгот и резет пассворд
     response_model=TokenReadSchemas,
     summary=Summary.TABIT_ADMIN_AUTH_REFRESH_TOKEN,
     description=Description.TABIT_ADMIN_AUTH_REFRESH_TOKEN,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def refresh_token_tabit_admin(
     user_and_refresh_token: tuple[TabitAdminUser, str] = Depends(get_current_admin_refresh_token),
@@ -271,7 +272,7 @@ async def refresh_token_tabit_admin(
     status_code=HTTPStatus.CREATED,
     summary=Summary.TABIT_ADMIN_AUTH_CREATE,
     description=Description.TABIT_ADMIN_AUTH_CREATE,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def create_tabit_admin(
     request: Request,
@@ -343,7 +344,7 @@ async def login(
     '/logout',
     summary=Summary.TABIT_ADMIN_AUTH_LOGOUT,
     description=Description.TABIT_ADMIN_AUTH_LOGOUT,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def logout(
     user_and_access_token: tuple[models.UP, str] = Depends(get_current_admin_token),

--- a/src/api/v1/endpoints/tabit_admin_auth.py
+++ b/src/api/v1/endpoints/tabit_admin_auth.py
@@ -40,6 +40,7 @@ router = APIRouter()
     dependencies=[Depends(current_superuser)],
     summary=Summary.TABIT_ADMIN_AUTH_LIST,
     description=Description.TABIT_ADMIN_AUTH_LIST,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def get_tabit_admin(
     session: AsyncSession = Depends(get_async_session),
@@ -64,6 +65,7 @@ async def get_tabit_admin(
     response_model=AdminReadSchema,
     summary=Summary.TABIT_ADMIN_AUTH_GET_ME,
     description=Description.TABIT_ADMIN_AUTH_GET_ME,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def get_me_tabit_admin(
     session: AsyncSession = Depends(get_async_session),
@@ -90,6 +92,7 @@ async def get_me_tabit_admin(
     response_model=AdminReadSchema,
     summary=Summary.TABIT_ADMIN_AUTH_PATCH_ME,
     description=Description.TABIT_ADMIN_AUTH_PATCH_ME,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def update_me_tabit_admin(
     user_in: AdminUpdateSchema,
@@ -119,6 +122,7 @@ async def update_me_tabit_admin(
     dependencies=[Depends(current_superuser)],
     summary=Summary.TABIT_ADMIN_AUTH_GET_BY_ID,
     description=Description.TABIT_ADMIN_AUTH_GET_BY_ID,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def get_tabit_admin_by_id(
     user_id: UUID,
@@ -146,6 +150,7 @@ async def get_tabit_admin_by_id(
     dependencies=[Depends(current_superuser)],
     summary=Summary.TABIT_ADMIN_AUTH_PATCH_BY_ID,
     description=Description.TABIT_ADMIN_AUTH_PATCH_BY_ID,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def update_tabit_admin_by_id(
     user_id: UUID,
@@ -181,6 +186,7 @@ async def update_tabit_admin_by_id(
     status_code=HTTPStatus.NO_CONTENT,
     summary=Summary.TABIT_ADMIN_AUTH_DELETE_BY_ID,
     description=Description.TABIT_ADMIN_AUTH_DELETE_BY_ID,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def delete_tabit_admin_by_id(
     user_id: UUID,
@@ -225,6 +231,7 @@ router.include_router(  # форгот и резет пассворд
     response_model=TokenReadSchemas,
     summary=Summary.TABIT_ADMIN_AUTH_REFRESH_TOKEN,
     description=Description.TABIT_ADMIN_AUTH_REFRESH_TOKEN,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def refresh_token_tabit_admin(
     user_and_refresh_token: tuple[TabitAdminUser, str] = Depends(get_current_admin_refresh_token),
@@ -264,6 +271,7 @@ async def refresh_token_tabit_admin(
     status_code=HTTPStatus.CREATED,
     summary=Summary.TABIT_ADMIN_AUTH_CREATE,
     description=Description.TABIT_ADMIN_AUTH_CREATE,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def create_tabit_admin(
     request: Request,
@@ -335,6 +343,7 @@ async def login(
     '/logout',
     summary=Summary.TABIT_ADMIN_AUTH_LOGOUT,
     description=Description.TABIT_ADMIN_AUTH_LOGOUT,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def logout(
     user_and_access_token: tuple[models.UP, str] = Depends(get_current_admin_token),

--- a/src/api/v1/endpoints/tabit_management.py
+++ b/src/api/v1/endpoints/tabit_management.py
@@ -10,6 +10,7 @@ from src.api.v1.validators import (
     check_company_and_department,
     check_telegram_username_for_duplicates,
 )
+from src.constants import OPENAPI_EXTRA_ADMIN_AUTH
 from src.database.db_depends import get_async_session
 from src.tabit_management.crud.admin_company import admin_company_crud
 from src.tabit_management.crud.admin_user import admin_user_crud
@@ -30,7 +31,7 @@ router = APIRouter()
     response_model=list[AdminCompanyResponseSchema],
     dependencies=[Depends(current_admin_tabit)],
     summary='Получить общую информацию по компаниям.',
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def get_all_info(
     session: AsyncSession = Depends(get_async_session),
@@ -54,7 +55,7 @@ async def get_all_info(
     response_model=list[CompanyAdminReadSchema],
     dependencies=[Depends(current_admin_tabit)],
     summary='Получить информацию по всем сотрудникам компаний.',
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def get_all_staff(
     session: AsyncSession = Depends(get_async_session),
@@ -78,7 +79,7 @@ async def get_all_staff(
     dependencies=[Depends(current_admin_tabit)],
     summary='Создать нового сотрудника компании.',
     response_model=CompanyAdminReadSchema,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def create_staff(
     create_data: CompanyAdminCreateSchema,
@@ -111,7 +112,7 @@ async def create_staff(
     summary='Получить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     response_model=CompanyAdminReadSchema,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def get_staff(
     user_id: UUID, user_manager: BaseUserManager = Depends(get_user_manager)
@@ -132,7 +133,7 @@ async def get_staff(
     summary='Полностью изменить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     response_model=CompanyAdminReadSchema,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def full_update_staff(
     user_id: UUID,
@@ -162,7 +163,7 @@ async def full_update_staff(
     summary='Частично изменить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     response_model=CompanyAdminReadSchema,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def update_staff(
     user_id: UUID,
@@ -192,7 +193,7 @@ async def update_staff(
     summary='Удалить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     status_code=status.HTTP_204_NO_CONTENT,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def delete_staff(user_id: UUID, user_manager: BaseUserManager = Depends(get_user_manager)):
     """
@@ -215,7 +216,7 @@ async def delete_staff(user_id: UUID, user_manager: BaseUserManager = Depends(ge
     '/staff/{user_id}/resetpassword',
     dependencies=[Depends(current_admin_tabit)],
     summary='Сброс пароля администратора. Не работает',
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def reset_password_staff(
     user_id: UUID,

--- a/src/api/v1/endpoints/tabit_management.py
+++ b/src/api/v1/endpoints/tabit_management.py
@@ -30,6 +30,7 @@ router = APIRouter()
     response_model=list[AdminCompanyResponseSchema],
     dependencies=[Depends(current_admin_tabit)],
     summary='Получить общую информацию по компаниям.',
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def get_all_info(
     session: AsyncSession = Depends(get_async_session),
@@ -53,6 +54,7 @@ async def get_all_info(
     response_model=list[CompanyAdminReadSchema],
     dependencies=[Depends(current_admin_tabit)],
     summary='Получить информацию по всем сотрудникам компаний.',
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def get_all_staff(
     session: AsyncSession = Depends(get_async_session),
@@ -76,6 +78,7 @@ async def get_all_staff(
     dependencies=[Depends(current_admin_tabit)],
     summary='Создать нового сотрудника компании.',
     response_model=CompanyAdminReadSchema,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def create_staff(
     create_data: CompanyAdminCreateSchema,
@@ -108,6 +111,7 @@ async def create_staff(
     summary='Получить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     response_model=CompanyAdminReadSchema,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def get_staff(
     user_id: UUID, user_manager: BaseUserManager = Depends(get_user_manager)
@@ -128,6 +132,7 @@ async def get_staff(
     summary='Полностью изменить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     response_model=CompanyAdminReadSchema,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def full_update_staff(
     user_id: UUID,
@@ -157,6 +162,7 @@ async def full_update_staff(
     summary='Частично изменить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     response_model=CompanyAdminReadSchema,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def update_staff(
     user_id: UUID,
@@ -186,6 +192,7 @@ async def update_staff(
     summary='Удалить информацию об администраторе.',
     dependencies=[Depends(current_admin_tabit)],
     status_code=status.HTTP_204_NO_CONTENT,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def delete_staff(user_id: UUID, user_manager: BaseUserManager = Depends(get_user_manager)):
     """
@@ -208,6 +215,7 @@ async def delete_staff(user_id: UUID, user_manager: BaseUserManager = Depends(ge
     '/staff/{user_id}/resetpassword',
     dependencies=[Depends(current_admin_tabit)],
     summary='Сброс пароля администратора. Не работает',
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def reset_password_staff(
     user_id: UUID,

--- a/src/api/v1/endpoints/tabit_management_companies.py
+++ b/src/api/v1/endpoints/tabit_management_companies.py
@@ -22,6 +22,7 @@ from src.companies.schemas import (
     CompanyUpdateSchema,
 )
 from src.companies.schemas.company import CompanyTypeFilterSchema
+from src.constants import OPENAPI_EXTRA_ADMIN_AUTH
 from src.database.db_depends import get_async_session
 
 router = APIRouter()
@@ -33,7 +34,7 @@ router = APIRouter()
     dependencies=[Depends(current_admin_tabit)],
     summary=Summary.TABIT_MANAGEMENT_COMPANY_LIST,
     description=Description.TABIT_MANAGEMENT_COMPANY_LIST,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def get_companies(
     session: AsyncSession = Depends(get_async_session),
@@ -65,7 +66,7 @@ async def get_companies(
     status_code=HTTPStatus.CREATED,
     summary=Summary.TABIT_MANAGEMENT_COMPANY_CREATE,
     description=Description.TABIT_MANAGEMENT_COMPANY_CREATE,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def create_company(
     company: CompanyCreateSchema,
@@ -101,7 +102,7 @@ async def create_company(
     dependencies=[Depends(current_admin_tabit)],
     summary=Summary.TABIT_MANAGEMENT_COMPANY_UPDATE,
     description=Description.TABIT_MANAGEMENT_COMPANY_UPDATE,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def update_company(
     company_slug: str,
@@ -140,7 +141,7 @@ async def update_company(
     status_code=HTTPStatus.NO_CONTENT,
     summary=Summary.TABIT_MANAGEMENT_COMPANY_DELETE,
     description=Description.TABIT_MANAGEMENT_COMPANY_DELETE,
-    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
+    openapi_extra=OPENAPI_EXTRA_ADMIN_AUTH,
 )
 async def delete_company(
     company_slug: str,

--- a/src/api/v1/endpoints/tabit_management_companies.py
+++ b/src/api/v1/endpoints/tabit_management_companies.py
@@ -33,6 +33,7 @@ router = APIRouter()
     dependencies=[Depends(current_admin_tabit)],
     summary=Summary.TABIT_MANAGEMENT_COMPANY_LIST,
     description=Description.TABIT_MANAGEMENT_COMPANY_LIST,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def get_companies(
     session: AsyncSession = Depends(get_async_session),
@@ -64,6 +65,7 @@ async def get_companies(
     status_code=HTTPStatus.CREATED,
     summary=Summary.TABIT_MANAGEMENT_COMPANY_CREATE,
     description=Description.TABIT_MANAGEMENT_COMPANY_CREATE,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def create_company(
     company: CompanyCreateSchema,
@@ -99,6 +101,7 @@ async def create_company(
     dependencies=[Depends(current_admin_tabit)],
     summary=Summary.TABIT_MANAGEMENT_COMPANY_UPDATE,
     description=Description.TABIT_MANAGEMENT_COMPANY_UPDATE,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def update_company(
     company_slug: str,
@@ -137,6 +140,7 @@ async def update_company(
     status_code=HTTPStatus.NO_CONTENT,
     summary=Summary.TABIT_MANAGEMENT_COMPANY_DELETE,
     description=Description.TABIT_MANAGEMENT_COMPANY_DELETE,
+    openapi_extra={'security': [{'jwt_auth_backend_admin': []}]},
 )
 async def delete_company(
     company_slug: str,

--- a/src/api/v1/routers.py
+++ b/src/api/v1/routers.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from fastapi.security import HTTPBearer
 
 from src.api.v1.endpoints import (
     auth_employees,
@@ -20,13 +21,22 @@ main_router = APIRouter(prefix='/api/v1')
 
 main_router.include_router(email_router, prefix='', tags=['Send Email'])
 main_router.include_router(
-    tabit_admin_auth_router, prefix='/admin/auth', tags=['Tabit Admin Auth']
+    tabit_admin_auth_router,
+    prefix='/admin/auth',
+    tags=['Tabit Admin Auth'],
+    dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
 main_router.include_router(
-    tabit_management_router, prefix='/admin', tags=['Tabit Management - Staff']
+    tabit_management_router,
+    prefix='/admin',
+    tags=['Tabit Management - Staff'],
+    dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
 main_router.include_router(
-    companies_management_router, prefix='/admin/companies', tags=['Tabit Management - Companies']
+    companies_management_router,
+    prefix='/admin/companies',
+    tags=['Tabit Management - Companies'],
+    dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
 main_router.include_router(
     licenses_router, prefix='/admin/licenses', tags=[' Tabit Management - licenses']

--- a/src/api/v1/routers.py
+++ b/src/api/v1/routers.py
@@ -1,5 +1,4 @@
-from fastapi import APIRouter, Depends
-from fastapi.security import HTTPBearer
+from fastapi import APIRouter
 
 from src.api.v1.endpoints import (
     auth_employees,
@@ -24,19 +23,12 @@ main_router.include_router(
     tabit_admin_auth_router,
     prefix='/admin/auth',
     tags=['Tabit Admin Auth'],
-    dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
 main_router.include_router(
-    tabit_management_router,
-    prefix='/admin',
-    tags=['Tabit Management - Staff'],
-    dependencies=[Depends(HTTPBearer(auto_error=False))],
+    tabit_management_router, prefix='/admin', tags=['Tabit Management - Staff']
 )
 main_router.include_router(
-    companies_management_router,
-    prefix='/admin/companies',
-    tags=['Tabit Management - Companies'],
-    dependencies=[Depends(HTTPBearer(auto_error=False))],
+    companies_management_router, prefix='/admin/companies', tags=['Tabit Management - Companies']
 )
 main_router.include_router(
     licenses_router, prefix='/admin/licenses', tags=[' Tabit Management - licenses']

--- a/src/constants.py
+++ b/src/constants.py
@@ -37,6 +37,8 @@ BASE64_STARTSWITH: str = 'data:image'
 
 MAX_NUMBER_PROBLEM: int = 3
 
+OPENAPI_EXTRA_ADMIN_AUTH = {'security': [{'jwt_auth_backend_admin': []}]}
+
 
 @dataclass
 class TextError:

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,10 @@
 from fastapi import FastAPI
-from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 
 from src.api.v1.routers import main_router
 from src.config import settings
 from src.logger import LoggingMiddleware
+from src.openapi import get_tabit_openapi
 from src.scripts import application_management
 
 app_v1 = FastAPI(
@@ -17,30 +17,7 @@ app_v1.middleware('http')(LoggingMiddleware())  # Add logging requests feature a
 app_v1.include_router(main_router)
 settings.media_folder.mkdir(parents=True, exist_ok=True)
 app_v1.mount(settings.media_url, StaticFiles(directory=settings.media_folder, html=True))
-
-
-def custom_openapi():
-    if app_v1.openapi_schema:
-        return app_v1.openapi_schema
-
-    openapi_schema = get_openapi(
-        title=settings.app_title,
-        description=settings.description,
-        version=settings.version,
-        routes=app_v1.routes,
-    )
-
-    openapi_schema['components']['securitySchemes']['jwt_auth_backend_admin'] = {
-        'type': 'http',
-        'scheme': 'bearer',
-        'bearerFormat': 'JWT',
-    }
-
-    app_v1.openapi_schema = openapi_schema
-    return app_v1.openapi_schema
-
-
-app_v1.openapi = custom_openapi
+app_v1.openapi = get_tabit_openapi(app_v1, settings)
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 
 from src.api.v1.routers import main_router
@@ -16,6 +17,30 @@ app_v1.middleware('http')(LoggingMiddleware())  # Add logging requests feature a
 app_v1.include_router(main_router)
 settings.media_folder.mkdir(parents=True, exist_ok=True)
 app_v1.mount(settings.media_url, StaticFiles(directory=settings.media_folder, html=True))
+
+
+def custom_openapi():
+    if app_v1.openapi_schema:
+        return app_v1.openapi_schema
+
+    openapi_schema = get_openapi(
+        title=settings.app_title,
+        description=settings.description,
+        version=settings.version,
+        routes=app_v1.routes,
+    )
+
+    openapi_schema['components']['securitySchemes']['jwt_auth_backend_admin'] = {
+        'type': 'http',
+        'scheme': 'bearer',
+        'bearerFormat': 'JWT',
+    }
+
+    app_v1.openapi_schema = openapi_schema
+    return app_v1.openapi_schema
+
+
+app_v1.openapi = custom_openapi
 
 
 def main():

--- a/src/openapi.py
+++ b/src/openapi.py
@@ -1,0 +1,29 @@
+from typing import Any, Callable
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+from src.config import Settings
+
+
+def get_tabit_openapi(app: FastAPI, settings: Settings) -> Callable:
+    """Вернет расширенное OpenAPI приложения Tabit."""
+
+    def tabit_openapi() -> dict[Any, Any]:
+        """Расширенное OpenAPI приложения Tabit."""
+        if not app.openapi_schema:
+            openapi_schema = get_openapi(
+                title=settings.app_title,
+                description=settings.description,
+                version=settings.version,
+                routes=app.routes,
+            )
+            openapi_schema['components']['securitySchemes']['jwt_auth_backend_admin'] = {
+                'type': 'http',
+                'scheme': 'bearer',
+                'bearerFormat': 'JWT',
+            }
+            app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    return tabit_openapi


### PR DESCRIPTION
Добавил возможность авторизации админом в документации.

Авторизация происходит через получение токена на эндпонте /api/v1/admin/auth/login.
Далее необходимо полученный токен ввести в jwt_auth_backend_admin  (http, Bearer)

![image](https://github.com/user-attachments/assets/16d5e456-74e2-41c2-9bfe-4c0cf9fb5d73)

После чего появляется возможность использовать ручки админа из документации.

![image](https://github.com/user-attachments/assets/bec0284c-a785-4cc3-bb43-9330786204cb)

![image](https://github.com/user-attachments/assets/efa658a7-9cbc-45a9-b324-d828ce4df6d5)

В отличии от предыдущего подхода через Depends(HTTPBearer(auto_error=False)), данный работает на уровне самой документации и не влияет на логику работы приложения.