### PR TITLE
Fix current_company_moderator check for current company

### DIFF
--- a/src/core/auth/dependencies.py
+++ b/src/core/auth/dependencies.py
@@ -4,11 +4,14 @@
 
 from http import HTTPStatus
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio.session import AsyncSession
 
 from src.core.auth.jwt import tabit_admin, tabit_user
 from src.core.constants import TextErrorBaseConstants
-from src.models import CompanyUser, CompanyUserRole
+from src.core.database.db_depends import get_async_session
+from src.models import Company, CompanyUser, CompanyUserRole
 
 current_superuser = tabit_admin.current_user(active=True, superuser=True)
 """Зависимость. Проверит, является ли пользователь суперпользователем. Вернет этого пользователя.
@@ -23,15 +26,25 @@ current_user_tabit = tabit_user.current_user(active=True)
 """
 
 
-def current_company_moderator(
+async def current_company_moderator(
+    request: Request,
     user: CompanyUser = Depends(current_user_tabit),
     message: str = TextErrorBaseConstants.FORBIDDEN_ROLE_MODERATOR,
+    session: AsyncSession = Depends(get_async_session),
 ) -> CompanyUser:
     """
     Зависимость. Проверит, является ли пользователь модератором от компании.
     Вернет этого пользователя.
     """
     if not user.role == CompanyUserRole.MODERATOR:
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN,
+            detail=message,
+        )
+    request_company_slug = request.path_params['company_slug']
+    result = await session.execute(select(Company).where(Company.id == user.company_id))
+    db_company_obj = result.scalars().first()
+    if db_company_obj.slug != request_company_slug:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN,
             detail=message,


### PR DESCRIPTION
Тикет вашего PR (если есть):
    _№ #310 

#Описание изменений

Добавлена проверка на принадлежность модератора компании к текущей компании, через слаг компании который идёт в запросе. Проверка добавленна в Depends зависимость "current_company_moderator"

__Когда создаёте активный PR (не черновик), убедитесь, что:__

- [ ] синхронизировали изменения кода с [ER-диаграммой базы данных](https://app.erdlab.io/designer/schema/1736745715-tabit) связей моделей;
- [ ] созданы необходимые миграции;
- [ ] все тесты пройдены (pytest -vs);
- [ ] все контейнеры запускаются локально (make up-dc) и корректно открываются в браузере (СУБД для БД);
- [ ] модель OpenAPI проверена (в Swagger отображаются изменения);
- [ ] код в вашей локальной ветке синхронизирован с веткой dev (git pull origin dev).


__Когда ваш PR одобрен для слияния с веткой dev:__

- [ ] протестируйте выполнение workflow "Deploy to Stage" для вашей ветки из PR:
  - перейдите во вкладку "Actions" GitHub репозитория проекта;
  -  в меню, расположенном в левой части экрана, выберите workflow с названием "Deploy to Stage";
  - над последним запущенным workflow выберите "Run workflow", выберите свою ветку из PR и запустите workflow, нажав на кнопку "Run workflow";
  - в случае успешного выполнения workflow сделайте merge с веткой dev.


__Когда ваш PR смержен:__

При наличии изменений в API, сообщите об этом команде frontend-разработки, им это важно знать!
