### PR TITLE
License check restriction employees before user creation add

### DIFF
--- a/src/crud/crud_user.py
+++ b/src/crud/crud_user.py
@@ -1,11 +1,33 @@
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio.session import AsyncSession
+
 from src.crud.crud_base import CRUDBase
-from src.models import CompanyUser
+from src.models import CompanyUser, CompanyUserRole
 
 
 class CRUDUsers(CRUDBase):
     """CRUD операций для модели пользователей."""
 
-    pass
+    async def get_company_employee_count(self, session: AsyncSession, company_id: int) -> int:
+        """
+        Возвращает общее количество сотрудников определенной компании в таблице CompanyUser.
+         Компания выбирается по ID "company_id".
 
+        Args:
+            session (AsyncSession): Асинхронная сессия SQLAlchemy.
+            company_id (int): ID Компании
+
+        Returns:
+            int: Общее количество сотрудников компании в таблице CompanyUser.
+        """
+        result = await session.execute(
+            select(func.count())
+            .select_from(CompanyUser)
+            .where(
+                CompanyUser.company_id == company_id,
+                CompanyUser.role == CompanyUserRole.EMPLOYEE
+            )
+        )
+        return result.scalar()
 
 user_crud = CRUDUsers(CompanyUser)

--- a/src/features_v1/company_moderator_management/endpoints.py
+++ b/src/features_v1/company_moderator_management/endpoints.py
@@ -10,12 +10,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.core.auth.dependencies import current_company_moderator
 from src.core.auth.managers import get_user_manager
 from src.core.database.db_depends import get_async_session
-from src.crud import company_crud, department_crud, moderator_crud
+from src.crud import company_crud, department_crud, license_type_crud, moderator_crud
 from src.features_v1.constants import SummaryConstants
 from src.features_v1.validators import (
     check_department_name_duplicate,
     check_slug_duplicate,
     check_telegram_username_for_duplicates,
+    validate_license_max_employees,
     validate_password,
     validate_user_not_exists,
     validator_check_object_exists,
@@ -399,6 +400,7 @@ async def create_company_employee(
     Создает сотрудника в компании.
     Доступно только пользователю-админу компании.
     Проверяет существует ли компания. Если нет, вернется ответ со статусом 404.
+    Проверяет не превышено ли максимальное количество сотрудников по лицензии
     В пути принимает 'company_slug' - значение `slug` компании.
     Параметры декоратора:
         path: URL-адрес, который будет использоваться для этой операции.
@@ -436,7 +438,13 @@ async def create_company_employee(
     }
     Если пользователь уже существует или пароль не соответствует требованиям ответ со статусом 400.
     """
-    await validator_check_object_exists(session, company_crud, object_slug=company_slug)
+    company_object_model = await validator_check_object_exists(
+        session, company_crud, object_slug=company_slug
+    )
+    company_license_id = getattr(company_object_model, 'license_id', None)
+    await validate_license_max_employees(
+        session, license_type_crud, company_license_id, company_object_model.id
+    )
     await validate_user_not_exists(create_data, user_manager)
     await validate_password(create_data, user_manager)
     await check_telegram_username_for_duplicates(create_data.telegram_username, session)

--- a/src/features_v1/validators.py
+++ b/src/features_v1/validators.py
@@ -6,9 +6,8 @@ from fastapi import Depends, HTTPException, status
 from fastapi_users.exceptions import InvalidPasswordException
 from fastapi_users.manager import BaseUserManager
 from slugify import slugify
-from sqlalchemy import UUID, select
+from sqlalchemy import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql.functions import func
 
 from src.core.auth.managers import get_user_manager
 from src.core.database.db_depends import get_async_session
@@ -33,7 +32,6 @@ from src.models import (
     CommentFeed,
     Company,
     CompanyUser,
-    CompanyUserRole,
     Department,
     Meeting,
     MeetingStatus,
@@ -736,14 +734,7 @@ async def validate_license_max_employees(
     license_object_model = await model_crud.get(session, license_id)
 
     if license_object_model is not None:
-        result = await session.execute(
-            select(func.count())
-            .select_from(CompanyUser)
-            .where(
-                CompanyUser.company_id == company_id, CompanyUser.role == CompanyUserRole.EMPLOYEE
-            )
-        )
-        count_company_employees = result.scalar()
+        count_company_employees = await user_crud.get_company_employee_count(session, company_id)
 
         if count_company_employees >= license_object_model.max_employees_count:
             raise HTTPException(

--- a/src/features_v1/validators.py
+++ b/src/features_v1/validators.py
@@ -6,8 +6,9 @@ from fastapi import Depends, HTTPException, status
 from fastapi_users.exceptions import InvalidPasswordException
 from fastapi_users.manager import BaseUserManager
 from slugify import slugify
-from sqlalchemy import UUID
+from sqlalchemy import UUID, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.functions import func
 
 from src.core.auth.managers import get_user_manager
 from src.core.database.db_depends import get_async_session
@@ -32,6 +33,7 @@ from src.models import (
     CommentFeed,
     Company,
     CompanyUser,
+    CompanyUserRole,
     Department,
     Meeting,
     MeetingStatus,
@@ -707,3 +709,45 @@ async def validate_license_name(session: AsyncSession, license_name: str):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Лицензия с именем '{license_name}' уже существует.",
         )
+
+
+async def validate_license_max_employees(
+    session: AsyncSession,
+    model_crud: CRUDBase,
+    license_id: int,
+    company_id: int,
+) -> None:
+    """
+    Проверяет, не превышено ли число сотрудников компании максимальному числу по лицензии.
+
+    Проверка происходит путём получения объекта лицензии принадлежащей к компании
+    и сравнения максимального количества сотрудников компании и лицензии.
+
+    Args:
+        session (AsyncSession): Асинхронная сессия SQLAlchemy.
+        model_crud (CRUDBase): CRUD Лицензии
+        license_id (int): ID лицензии компании, которую нужно проверить.
+        company_id (int): ID компании.
+
+    Raises:
+        HTTPException: Если превышено максимальное количество сотрудников,
+                        возвращает ошибку 400 (BAD REQUEST).
+    """
+    license_object_model = await model_crud.get(session, license_id)
+
+    if license_object_model is not None:
+        result = await session.execute(
+            select(func.count())
+            .select_from(CompanyUser)
+            .where(
+                CompanyUser.company_id == company_id, CompanyUser.role == CompanyUserRole.EMPLOYEE
+            )
+        )
+        count_company_employees = result.scalar()
+
+        if count_company_employees >= license_object_model.max_employees_count:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f'Превышено максимальное количество сотрудников по'
+                f" лицензии №'{license_id}'",
+            )

--- a/src/features_v1/validators.py
+++ b/src/features_v1/validators.py
@@ -739,6 +739,6 @@ async def validate_license_max_employees(
         if count_company_employees >= license_object_model.max_employees_count:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f'Превышено максимальное количество сотрудников по'
+                detail='Превышено максимальное количество сотрудников по'
                 f" лицензии №'{license_id}'",
             )


### PR DESCRIPTION
#313 

Добавлена проверка на превышение числа сотрудников компании максимально допустимому числу сотрудников по лицензии. Проверка происходит путём получения объекта лицензии принадлежащей к компании и сравнения максимального количества сотрудников компании и лицензии.

Создан новый метод get_company_employee_count() в crud_user для подсчёта количества сотрудников компании

