### PR TITLE
Add admins max license check validation, get_company_admins_count() i…

### DIFF
--- a/src/crud/crud_user.py
+++ b/src/crud/crud_user.py
@@ -1,11 +1,33 @@
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio.session import AsyncSession
+
 from src.crud.crud_base import CRUDBase
-from src.models import CompanyUser
+from src.models import CompanyUser, CompanyUserRole
 
 
 class CRUDUsers(CRUDBase):
     """CRUD операций для модели пользователей."""
 
-    pass
+    async def get_company_admins_count(self, session: AsyncSession, company_id: int) -> int:
+        """
+        Возвращает общее количество админов определенной компании в таблице CompanyUser.
+         Компания выбирается по ID "company_id".
 
+        Args:
+            session (AsyncSession): Асинхронная сессия SQLAlchemy.
+            company_id (int): ID Компании
+
+        Returns:
+            int: Общее количество админов компании в таблице CompanyUser.
+        """
+        result = await session.execute(
+            select(func.count())
+            .select_from(CompanyUser)
+            .where(
+                CompanyUser.company_id == company_id,
+                CompanyUser.role == CompanyUserRole.MODERATOR,
+            )
+        )
+        return result.scalar()
 
 user_crud = CRUDUsers(CompanyUser)

--- a/src/features_v1/tabit_admin_management/endpoints.py
+++ b/src/features_v1/tabit_admin_management/endpoints.py
@@ -7,11 +7,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.core.auth.dependencies import current_admin_tabit
 from src.core.auth.managers import get_user_manager
 from src.core.database.db_depends import get_async_session
-from src.crud import admin_company_crud, moderator_crud
+from src.crud import admin_company_crud, company_crud, license_type_crud, moderator_crud
 from src.features_v1.constants import MiscConstants
 from src.features_v1.validators import (
     check_company_and_department,
     check_telegram_username_for_duplicates,
+    validate_license_max_admins,
+    validator_check_object_exists,
 )
 from src.schemas import (
     AdminCompanyResponseSchema,
@@ -100,6 +102,13 @@ async def create_staff(
 
     Эндпоинт доступен только админам сервиса.
     """
+    company_object_model = await validator_check_object_exists(
+        session, company_crud, object_id=create_data.company_id
+    )
+    company_license_id = getattr(company_object_model, 'license_id', None)
+    await validate_license_max_admins(
+        session, license_type_crud, company_license_id, company_object_model.id
+    )
     await check_company_and_department(
         create_data.company_id, create_data.current_department_id, session
     )

--- a/src/features_v1/validators.py
+++ b/src/features_v1/validators.py
@@ -707,3 +707,38 @@ async def validate_license_name(session: AsyncSession, license_name: str):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Лицензия с именем '{license_name}' уже существует.",
         )
+
+
+async def validate_license_max_admins(
+    session: AsyncSession,
+    model_crud: CRUDBase,
+    license_id: int,
+    company_id: int,
+) -> None:
+    """
+    Проверяет, не превышено ли число модераторов компании максимальному числу по лицензии.
+
+    Проверка происходит путём получения объекта лицензии принадлежащей к компании
+    и сравнения максимального количества модераторов компании и лицензии.
+
+    Args:
+        session (AsyncSession): Асинхронная сессия SQLAlchemy.
+        model_crud (CRUDBase): CRUD Лицензии
+        license_id (int): ID лицензии компании, которую нужно проверить.
+        company_id (int): ID компании.
+
+    Raises:
+        HTTPException: Если превышено максимальное количество админов,
+                        возвращает ошибку 400 (BAD REQUEST).
+    """
+    license_object_model = await model_crud.get(session, license_id)
+
+    if license_object_model is not None:
+        count_company_admins = await user_crud.get_company_admins_count(session, company_id)
+
+        if count_company_admins >= license_object_model.max_admins_count:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f'Превышено максимальное количество модераторов по'
+                f" лицензии №'{license_id}'",
+            )

--- a/src/features_v1/validators.py
+++ b/src/features_v1/validators.py
@@ -739,6 +739,6 @@ async def validate_license_max_admins(
         if count_company_admins >= license_object_model.max_admins_count:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f'Превышено максимальное количество модераторов по'
+                detail='Превышено максимальное количество модераторов по'
                 f" лицензии №'{license_id}'",
             )

--- a/tests/test_tabit_management_staff.py
+++ b/tests/test_tabit_management_staff.py
@@ -17,16 +17,16 @@ class TestGetTabitManagement:
         """Тест для проверки получения списка компаний."""
         ten_companies = [await company_for_test() for _ in range(10)]
         response = await client.get(UrlConstants.ADMIN_GET_COMPANIES, headers=admin_token)
-        assert response.status_code == status.HTTP_200_OK, (
-            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
-        )
+        assert (
+            response.status_code == status.HTTP_200_OK
+        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
         result = response.json()
-        assert isinstance(result, list), (
-            f'В качестве ответа должен быть получен list, пришёл {type(result)}'
-        )
-        assert len(result) == len(ten_companies), (
-            f'Длина полученного списка должна быть равна {len(ten_companies)}'
-        )
+        assert isinstance(
+            result, list
+        ), f'В качестве ответа должен быть получен list, пришёл {type(result)}'
+        assert len(result) == len(
+            ten_companies
+        ), f'Длина полученного списка должна быть равна {len(ten_companies)}'
 
     @pytest.mark.skip(reason='Нет возможности протестировать')
     async def test_get_paginated_companies_info(
@@ -52,16 +52,16 @@ class TestGetTabitManagement:
             for _ in range(10)
         ]
         response = await client.get(UrlConstants.ADMIN_MODS_URL, headers=admin_token)
-        assert response.status_code == status.HTTP_200_OK, (
-            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
-        )
+        assert (
+            response.status_code == status.HTTP_200_OK
+        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
         result = response.json()
-        assert isinstance(result, list), (
-            f'В качестве ответа должен быть получен list, пришёл {type(result)}'
-        )
-        assert len(result) == len(ten_mods), (
-            f'Длина полученного списка должна быть равна {len(ten_mods)}'
-        )
+        assert isinstance(
+            result, list
+        ), f'В качестве ответа должен быть получен list, пришёл {type(result)}'
+        assert len(result) == len(
+            ten_mods
+        ), f'Длина полученного списка должна быть равна {len(ten_mods)}'
 
     @pytest.mark.skip(reason='Нет возможности протестировать')
     async def test_get_paginated_multiple_staff(
@@ -96,9 +96,9 @@ class TestGetTabitManagement:
                 ),
                 headers=admin_token,
             )
-        assert response.status_code == status_code, (
-            f'В ответе ожидается status_code {status_code}, получен {response.status_code}'
-        )
+        assert (
+            response.status_code == status_code
+        ), f'В ответе ожидается status_code {status_code}, получен {response.status_code}'
 
 
 @pytest.mark.asyncio(loop_scope='session')
@@ -118,9 +118,9 @@ class TestPostTabitManagement:
                 **{'company_id': department.company_id, 'current_department_id': department.id},
             },
         )
-        assert response.status_code == status.HTTP_200_OK, (
-            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
-        )
+        assert (
+            response.status_code == status.HTTP_200_OK
+        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
         result = response.json()
         for key in TabitManagementDataConstants.ADMIN_CREATE_MOD_NEW:
             if key != 'password':
@@ -129,7 +129,19 @@ class TestPostTabitManagement:
         assert result['current_department_id'] == department.id
         assert result['previous_department_id'] is None
 
-    @pytest.mark.parametrize('payload', TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD)
+
+    @pytest.mark.parametrize(
+        'payload, expected_status',
+        [
+            (TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD[0], 422),
+            (TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD[1], 422),
+            (TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD[2], 422),
+            (TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD[3], 422),
+            (TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD[4], 404),
+            (TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD[5], 422),
+            (TabitManagementDataConstants.ADMIN_CREATE_MOD_BAD[6], 422),
+        ]
+    )
     async def test_unsuccessful_create_moderator(
         self,
         async_session: AsyncSession,
@@ -139,6 +151,7 @@ class TestPostTabitManagement:
         department_for_test,
         moderator_of_company,
         payload,
+        expected_status
     ):
         """Тест для проверки неуспешного создания модератора"""
         department = await department_for_test()
@@ -154,8 +167,8 @@ class TestPostTabitManagement:
         response = await client.post(
             UrlConstants.ADMIN_MODS_URL, headers=admin_token, json=payload
         )
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, (
-            f'В ответе ожидается status_code {status.HTTP_422_UNPROCESSABLE_ENTITY}, '
+        assert response.status_code == expected_status, (
+            f'В ответе ожидается status_code {expected_status}, '
             f'получен {response.status_code}'
         )
         new_user_count = await get_count(async_session, CompanyUser)
@@ -192,9 +205,9 @@ class TestUpdateTabitManagement:
             headers=admin_token,
             json=payload,
         )
-        assert response.status_code == status.HTTP_200_OK, (
-            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
-        )
+        assert (
+            response.status_code == status.HTTP_200_OK
+        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
         result = response.json()
         for key in payload:
             assert result[key] == payload[key]
@@ -240,9 +253,9 @@ class TestUpdateTabitManagement:
         )
         moderator = await async_session.merge(moderator)
         new_moderator_data = await update_object(async_session, moderator)
-        assert new_moderator_data == old_moderator_data, (
-            'При неуспешном PATCH-запросе объект пользователя не должен меняться'
-        )
+        assert (
+            new_moderator_data == old_moderator_data
+        ), 'При неуспешном PATCH-запросе объект пользователя не должен меняться'
 
     @pytest.mark.parametrize(
         'payload, check_department_change', TabitManagementDataConstants.ADMIN_PUT_MOD
@@ -267,9 +280,9 @@ class TestUpdateTabitManagement:
             headers=admin_token,
             json=payload,
         )
-        assert response.status_code == status.HTTP_200_OK, (
-            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
-        )
+        assert (
+            response.status_code == status.HTTP_200_OK
+        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
         result = response.json()
         for key in payload:
             if key != 'password':
@@ -316,9 +329,9 @@ class TestUpdateTabitManagement:
         )
         moderator = await async_session.merge(moderator)
         new_moderator_data = await update_object(async_session, moderator)
-        assert new_moderator_data == old_moderator_data, (
-            'При неуспешном PUT-запросе объект пользователя не должен меняться'
-        )
+        assert (
+            new_moderator_data == old_moderator_data
+        ), 'При неуспешном PUT-запросе объект пользователя не должен меняться'
 
     async def test_update_404(self, client: AsyncClient, admin_token):
         """Тест для проверки PATCH- и PUT- запросов к несуществующему пользователю"""


### PR DESCRIPTION
#314 

Добавлена проверка на ограничение количества админов по лицензии при создании админа компании, Post запросом на эндпоинт /api/v1/admin/staff
Запрос проходит валидацию через метод validate_license_max_admins() который вызывает метод get_company_admins_count() для подсчёта количества админов компании из crud_user.py

Также изменены параметры в тесте test_unsuccessful_create_moderator() чтобы проверка проходила валидно. Автоматически Ruff  сделал форматрование в этом файле tests/test_tabit_management_staff.py