### PR TITLE
Добавлены эндпоинты для аутентификации модераторов компаний

### DIFF
--- a/src/api/v1/routers.py
+++ b/src/api/v1/routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from src.features_v1 import (
     company_enums_router,
     company_feedback_router,
+    company_moderator_auth_router,
     company_moderator_management_router,
     company_problem_discussion_router,
     company_problem_management_router,
@@ -42,6 +43,11 @@ main_router.include_router(
 
 # Company Endpoints
 main_router.include_router(company_user_auth_router, prefix='/auth', tags=['Company User Auth'])
+main_router.include_router(
+    company_moderator_auth_router,
+    prefix='/{company_slug}/moderator/auth',
+    tags=['Company Moderator Auth'],
+)
 main_router.include_router(
     company_moderator_management_router,
     prefix='/{company_slug}',

--- a/src/crud/crud_admin_user.py
+++ b/src/crud/crud_admin_user.py
@@ -5,13 +5,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.crud import UserCreateMixin
-from src.crud.crud_user import CRUDUsers  # Наследуем от CRUDUsers
+from src.crud.crud_password_mixin import CRUDPasswordMixin
+from src.crud.crud_user import CRUDUsers
 from src.models import TabitAdminUser
 
 logger = logging.getLogger(__name__)
 
 
-class CRUDAdminUser(UserCreateMixin, CRUDUsers):
+class CRUDAdminUser(UserCreateMixin, CRUDPasswordMixin, CRUDUsers):
     """CRUD операций для моделей администраторов сервиса Табит."""
 
     async def get_by_email(self, session: AsyncSession, email: str) -> TabitAdminUser | None:

--- a/src/crud/crud_admin_user.py
+++ b/src/crud/crud_admin_user.py
@@ -5,14 +5,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.crud import UserCreateMixin
-from src.crud.crud_password_mixin import CRUDPasswordMixin
 from src.crud.crud_user import CRUDUsers
 from src.models import TabitAdminUser
 
 logger = logging.getLogger(__name__)
 
 
-class CRUDAdminUser(UserCreateMixin, CRUDPasswordMixin, CRUDUsers):
+class CRUDAdminUser(UserCreateMixin, CRUDUsers):
     """CRUD операций для моделей администраторов сервиса Табит."""
 
     async def get_by_email(self, session: AsyncSession, email: str) -> TabitAdminUser | None:

--- a/src/crud/crud_moderator.py
+++ b/src/crud/crud_moderator.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.crud import CRUDBase, UserCreateMixin
 from src.crud.constants import TextErrorConstants
+from src.crud.crud_password_mixin import CRUDPasswordMixin
 from src.models import CompanyUser
 from src.schemas import (
     CompanyAdminCreateSchema,
@@ -16,18 +17,20 @@ from src.schemas import (
 )
 
 
-class CRUDModeratorUser(UserCreateMixin, CRUDBase):
+class CRUDModeratorUser(UserCreateMixin, CRUDPasswordMixin, CRUDBase):
     """CRUD операций для моделей модераторов компаний."""
 
     async def get_by_telegram_username(
         self, username: str, session: AsyncSession
     ) -> CompanyUser | None:
         """
-        Функция, возвращающая объект пользователя CompanyUser по переданному telegram_username,
-        или же возвращающая значение None, если пользователь не обнаружен.
+        Функция, возвращающая объект пользователя CompanyUser по переданному
+        telegram_username, или же возвращающая значение None, если пользователь
+        не обнаружен.
 
         Параметры:
-            username: переданное значение telegram_username, по которому будет происходить поиск;
+            username: переданное значение telegram_username, по которому будет
+            происходить поиск;
             session: асинхронная сессия SQLAlchemy;
         """
         user = await session.execute(
@@ -254,8 +257,8 @@ class CRUDModeratorUser(UserCreateMixin, CRUDBase):
         user_manager: BaseUserManager,
     ) -> CompanyUser:
         """
-        Переопределённый метод create от CRUDBase. Возвращает созданный объект UserTabit.
-        В случае возникновения ошибок, выбрасывает исключения.
+        Переопределённый метод create от CRUDBase. Возвращает созданный объект
+        UserTabit. В случае возникновения ошибок, выбрасывает исключения.
 
         Параметры:
             create_data: Валидированные данные схемы CompanyAdminCreateSchema,
@@ -283,9 +286,11 @@ class CRUDModeratorUser(UserCreateMixin, CRUDBase):
         user_manager: BaseUserManager,
     ) -> CompanyUser:
         """
-        Переопределённый метод update от CRUDBase. Функция обновляет данные админа от компании.
+        Переопределённый метод update от CRUDBase. Функция обновляет данные
+        админа от компании.
 
-        Получает объект пользователя по UUID, обновляет его данные в БД и возвращает его.
+        Получает объект пользователя по UUID, обновляет его данные в БД и
+        возвращает его.
         Параметры:
             user_id - UUID пользователя;
             update_date: объект схемы с данными для обновления;
@@ -321,7 +326,8 @@ class CRUDModeratorUser(UserCreateMixin, CRUDBase):
         """
         Переопределённый метод remove от CRUDBase. Функция удалёет из БД запись об
         объекте UserTabit с переданным UUID.
-        Если пользователь с указанным UUID не найден, то выбрасывается исключение HTTP 404.
+        Если пользователь с указанным UUID не найден, то выбрасывается
+        исключение HTTP 404.
 
         Параметры:
             user_id - UUID пользователя;

--- a/src/crud/crud_moderator.py
+++ b/src/crud/crud_moderator.py
@@ -17,7 +17,7 @@ from src.schemas import (
 
 
 class CRUDModeratorUser(UserCreateMixin, CRUDBase):
-    """CRUD операций для моделей администраторов сервиса Табит."""
+    """CRUD операций для моделей модераторов компаний."""
 
     async def get_by_telegram_username(
         self, username: str, session: AsyncSession
@@ -34,6 +34,219 @@ class CRUDModeratorUser(UserCreateMixin, CRUDBase):
             select(self.model).where(self.model.telegram_username == username)
         )
         return user.scalars().first()
+
+    async def get_by_email(self, session: AsyncSession, email: str) -> CompanyUser | None:
+        """Получает модератора по email"""
+        result = await session.execute(select(self.model).where(self.model.email == email))
+        return result.scalars().first()
+
+    async def get_by_id(self, session: AsyncSession, user_id: str) -> CompanyUser | None:
+        """Получает модератора по ID"""
+        result = await session.execute(select(self.model).where(self.model.id == user_id))
+        return result.scalars().first()
+
+    async def create_password_reset_token(self, session: AsyncSession, email: str) -> str:
+        """Создает токен для восстановления пароля используя JWT"""
+        # Получаем модератора
+        user = await self.get_by_email(session, email)
+        if not user:
+            raise ValueError('Модератор не найден')
+
+        # Проверяем, что это действительно модератор
+        from src.models import CompanyUserRole
+
+        if user.role != CompanyUserRole.MODERATOR:
+            raise ValueError('Пользователь не является модератором')
+
+        # Используем JWT стратегию для генерации токена
+        from src.core.auth.jwt import get_jwt_strategy
+
+        jwt_strategy = get_jwt_strategy()
+        token = await jwt_strategy.generate_password_reset_token(str(user.id), email)
+
+        return token
+
+    async def verify_reset_token(self, session: AsyncSession, token: str) -> bool:
+        """Проверяет токен восстановления пароля используя JWT"""
+        try:
+            # Используем JWT стратегию для проверки токена
+            from src.core.auth.jwt import get_jwt_strategy
+
+            jwt_strategy = get_jwt_strategy()
+            payload = await jwt_strategy.verify_password_reset_token(token)
+
+            # Проверяем существование модератора
+            user = await self.get_by_id(session, payload['sub'])
+            if not user:
+                return False
+
+            # Проверяем, что это действительно модератор
+            from src.models import CompanyUserRole
+
+            return user.role == CompanyUserRole.MODERATOR
+
+        except (ValueError, KeyError):
+            return False
+
+    async def reset_password_with_token(
+        self, session: AsyncSession, token: str, new_password: str
+    ) -> bool:
+        """Сбрасывает пароль с использованием JWT токена"""
+        try:
+            # Проверяем токен и получаем payload
+            from src.core.auth.jwt import get_jwt_strategy
+
+            jwt_strategy = get_jwt_strategy()
+            payload = await jwt_strategy.verify_password_reset_token(token)
+
+            # Получаем модератора
+            user = await self.get_by_id(session, payload['sub'])
+            if not user:
+                return False
+
+            # Проверяем, что это действительно модератор
+            from src.models import CompanyUserRole
+
+            if user.role != CompanyUserRole.MODERATOR:
+                return False
+
+            # Обновляем пароль используя JWT стратегию
+            hashed_password = jwt_strategy.password_helper.hash(new_password)
+            user.hashed_password = hashed_password
+
+            await session.commit()
+            return True
+
+        except ValueError:
+            return False
+
+    async def reset_password_by_admin(
+        self, session: AsyncSession, user_id: UUID, new_password: str
+    ) -> bool:
+        """Принудительный сброс пароля администратором"""
+        try:
+            user = await self.get_or_404(session, user_id)
+
+            # Проверяем, что это действительно модератор
+            from src.models import CompanyUserRole
+
+            if user.role != CompanyUserRole.MODERATOR:
+                return False
+
+            # Хешируем новый пароль
+            from fastapi_users.password import PasswordHelper
+
+            password_helper = PasswordHelper()
+            hashed_password = password_helper.hash(new_password)
+
+            # Обновляем пароль
+            user.hashed_password = hashed_password
+            session.add(user)
+            await session.commit()
+
+            return True
+
+        except Exception as e:
+            await session.rollback()
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.error(f'Ошибка при сбросе пароля модератора: {e}')
+            return False
+
+    async def verify_password(self, session: AsyncSession, user_id: UUID, password: str) -> bool:
+        """Проверка текущего пароля модератора"""
+        try:
+            user = await self.get_or_404(session, user_id)
+
+            # Проверяем, что это действительно модератор
+            from src.models import CompanyUserRole
+
+            if user.role != CompanyUserRole.MODERATOR:
+                return False
+
+            # Проверяем, что у модератора есть хешированный пароль
+            if not user.hashed_password:
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.warning('У модератора нет хешированного пароля')
+                return False
+
+            # Используем тот же PasswordHelper, что и в менеджерах
+            from fastapi_users.password import PasswordHelper
+
+            password_helper = PasswordHelper()
+
+            try:
+                # Проверяем пароль используя правильный метод
+                is_valid, _ = password_helper.verify_and_update(password, user.hashed_password)
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.debug(f'Проверка пароля для модератора {user_id}: {is_valid}')
+                return is_valid
+
+            except Exception as verify_error:
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.error(f'Ошибка при проверке пароля модератора: {verify_error}')
+                return False
+
+        except Exception as e:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.error(f'Ошибка при проверке пароля модератора: {e}')
+            return False
+
+    async def change_password(
+        self, session: AsyncSession, user_id: UUID, new_password: str
+    ) -> bool:
+        """Смена пароля модератором"""
+        try:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.info(f'Начинаем смену пароля для модератора {user_id}')
+            user = await self.get_or_404(session, user_id)
+            logger.debug(f'Модератор найден: {user.id}')
+
+            # Проверяем, что это действительно модератор
+            from src.models import CompanyUserRole
+
+            if user.role != CompanyUserRole.MODERATOR:
+                logger.warning(f'Пользователь {user_id} не является модератором')
+                return False
+
+            # Используем тот же PasswordHelper, что и в менеджерах
+            from fastapi_users.password import PasswordHelper
+
+            password_helper = PasswordHelper()
+            hashed_password = password_helper.hash(new_password)
+            logger.debug(f'Новый хеш создан: {hashed_password[:20]}...')
+
+            user.hashed_password = hashed_password
+            session.add(user)
+            logger.debug('Модератор добавлен в сессию')
+
+            await session.commit()
+            logger.info('Транзакция зафиксирована')
+
+            return True
+
+        except Exception as e:
+            await session.rollback()
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.error(f'Ошибка при смене пароля модератора: {e}')
+            logger.error(f'Тип ошибки: {type(e)}')
+            import traceback
+
+            logger.error(f'Traceback: {traceback.format_exc()}')
+            return False
 
     async def create(
         self,

--- a/src/crud/crud_password_mixin.py
+++ b/src/crud/crud_password_mixin.py
@@ -1,0 +1,188 @@
+"""Базовый миксин для CRUD операций с паролями."""
+
+import logging
+from typing import Generic, TypeVar
+from uuid import UUID
+
+from fastapi_users.password import PasswordHelper
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth.jwt import get_jwt_strategy
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T')
+
+
+class CRUDPasswordMixin(Generic[T]):
+    """Миксин с общими методами для работы с паролями пользователей."""
+
+    async def get_by_email(self, session: AsyncSession, email: str) -> T | None:
+        """Получает пользователя по email"""
+        result = await session.execute(
+            self.model.__table__.select().where(self.model.email == email)
+        )
+        return result.scalars().first()
+
+    async def get_by_id(self, session: AsyncSession, user_id: str) -> T | None:
+        """Получает пользователя по ID"""
+        result = await session.execute(
+            self.model.__table__.select().where(self.model.id == user_id)
+        )
+        return result.scalars().first()
+
+    async def create_password_reset_token(self, session: AsyncSession, email: str) -> str:
+        """Создает токен для восстановления пароля используя JWT"""
+        # Получаем пользователя
+        user = await self.get_by_email(session, email)
+        if not user:
+            raise ValueError('Пользователь не найден')
+
+        # Используем JWT стратегию для генерации токена
+        jwt_strategy = get_jwt_strategy()
+        token = await jwt_strategy.generate_password_reset_token(str(user.id), email)
+
+        return token
+
+    async def verify_reset_token(self, session: AsyncSession, token: str) -> bool:
+        """Проверяет токен восстановления пароля используя JWT"""
+        try:
+            # Используем JWT стратегию для проверки токена
+            jwt_strategy = get_jwt_strategy()
+            payload = await jwt_strategy.verify_password_reset_token(token)
+
+            # Проверяем существование пользователя
+            user = await self.get_by_id(session, payload['sub'])
+            return user is not None
+
+        except (ValueError, KeyError):
+            return False
+
+    async def reset_password_with_token(
+        self, session: AsyncSession, token: str, new_password: str
+    ) -> bool:
+        """Сбрасывает пароль с использованием JWT токена"""
+        try:
+            # Проверяем токен и получаем payload
+            jwt_strategy = get_jwt_strategy()
+            payload = await jwt_strategy.verify_password_reset_token(token)
+
+            # Получаем пользователя
+            user = await self.get_by_id(session, payload['sub'])
+            if not user:
+                return False
+
+            # Обновляем пароль используя JWT стратегию
+            hashed_password = jwt_strategy.password_helper.hash(new_password)
+            user.hashed_password = hashed_password
+
+            await session.commit()
+            return True
+
+        except ValueError:
+            return False
+
+    async def reset_password_by_admin(
+        self, session: AsyncSession, user_id: UUID, new_password: str
+    ) -> bool:
+        """Принудительный сброс пароля администратором"""
+        try:
+            user = await self.get_or_404(session, user_id)
+
+            # Хешируем новый пароль
+            password_helper = PasswordHelper()
+            hashed_password = password_helper.hash(new_password)
+
+            # Обновляем пароль
+            user.hashed_password = hashed_password
+            session.add(user)
+            await session.commit()
+
+            return True
+
+        except Exception as e:
+            await session.rollback()
+            logger.error(f'Ошибка при сбросе пароля: {e}')
+            return False
+
+    def _hash_password(self, password: str) -> str:
+        """Хеширует пароль используя JWT стратегию"""
+        jwt_strategy = get_jwt_strategy()
+        return jwt_strategy.password_helper.hash(password)
+
+    async def verify_password(self, session: AsyncSession, user_id: UUID, password: str) -> bool:
+        """Проверка текущего пароля пользователя"""
+        try:
+            user = await self.get_or_404(session, user_id)
+
+            # Проверяем, что у пользователя есть хешированный пароль
+            if not user.hashed_password:
+                logger.warning('У пользователя нет хешированного пароля')
+                return False
+
+            # Используем тот же PasswordHelper, что и в менеджерах
+            password_helper = PasswordHelper()
+
+            try:
+                # Проверяем пароль используя правильный метод
+                is_valid, _ = password_helper.verify_and_update(password, user.hashed_password)
+                logger.debug(f'Проверка пароля для пользователя {user_id}: {is_valid}')
+                return is_valid
+
+            except Exception as verify_error:
+                logger.error(f'Ошибка при проверке пароля: {verify_error}')
+                return False
+
+        except Exception as e:
+            logger.error(f'Ошибка при проверке пароля: {e}')
+            return False
+
+    async def change_password(
+        self, session: AsyncSession, user_id: UUID, new_password: str
+    ) -> bool:
+        """Смена пароля пользователем"""
+        try:
+            logger.info(f'Начинаем смену пароля для пользователя {user_id}')
+            user = await self.get_or_404(session, user_id)
+            logger.debug(f'Пользователь найден: {user.id}')
+
+            # Используем тот же PasswordHelper, что и в менеджерах
+            password_helper = PasswordHelper()
+            hashed_password = password_helper.hash(new_password)
+            logger.debug(f'Новый хеш создан: {hashed_password[:20]}...')
+
+            user.hashed_password = hashed_password
+            session.add(user)
+            logger.debug('Пользователь добавлен в сессию')
+
+            await session.commit()
+            logger.info('Транзакция зафиксирована')
+
+            return True
+
+        except Exception as e:
+            await session.rollback()
+            logger.error(f'Ошибка при смене пароля: {e}')
+            logger.error(f'Тип ошибки: {type(e)}')
+            import traceback
+
+            logger.error(f'Traceback: {traceback.format_exc()}')
+            return False
+
+    async def debug_password_hash(self, session: AsyncSession, user_id: UUID) -> dict:
+        """Диагностика хеша пароля пользователя"""
+        try:
+            user = await self.get_or_404(session, user_id)
+
+            return {
+                'user_id': str(user_id),
+                'has_password': bool(user.hashed_password),
+                'hash_length': (len(user.hashed_password) if user.hashed_password else 0),
+                'hash_prefix': (user.hashed_password[:10] if user.hashed_password else None),
+                'is_bcrypt_format': (
+                    user.hashed_password.startswith('$2b$') if user.hashed_password else False
+                ),
+            }
+
+        except Exception as e:
+            return {'error': str(e)}

--- a/src/crud/crud_user.py
+++ b/src/crud/crud_user.py
@@ -1,23 +1,22 @@
 import logging
-from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio.session import AsyncSession
 
-from src.core.auth.jwt import get_jwt_strategy
 from src.crud.crud_base import CRUDBase
+from src.crud.crud_password_mixin import CRUDPasswordMixin
 from src.models import CompanyUser, CompanyUserRole
 
 logger = logging.getLogger(__name__)
 
 
-class CRUDUsers(CRUDBase):
+class CRUDUsers(CRUDPasswordMixin, CRUDBase):
     """CRUD операций для модели пользователей."""
 
     async def get_company_employee_count(self, session: AsyncSession, company_id: int) -> int:
         """
-        Возвращает общее количество сотрудников определенной компании в таблице CompanyUser.
-         Компания выбирается по ID "company_id".
+        Возвращает общее количество сотрудников определенной компании в таблице
+        CompanyUser. Компания выбирается по ID "company_id".
 
         Args:
             session (AsyncSession): Асинхронная сессия SQLAlchemy.
@@ -37,8 +36,8 @@ class CRUDUsers(CRUDBase):
 
     async def get_company_admins_count(self, session: AsyncSession, company_id: int) -> int:
         """
-        Возвращает общее количество админов определенной компании в таблице CompanyUser.
-         Компания выбирается по ID "company_id".
+        Возвращает общее количество админов определенной компании в таблице
+        CompanyUser. Компания выбирается по ID "company_id".
 
         Args:
             session (AsyncSession): Асинхронная сессия SQLAlchemy.
@@ -56,178 +55,6 @@ class CRUDUsers(CRUDBase):
             )
         )
         return result.scalar()
-
-    async def get_by_email(self, session: AsyncSession, email: str) -> CompanyUser | None:
-        """Получает пользователя по email"""
-        result = await session.execute(select(self.model).where(self.model.email == email))
-        return result.scalars().first()
-
-    async def get_by_id(self, session: AsyncSession, user_id: str) -> CompanyUser | None:
-        """Получает пользователя по ID"""
-        result = await session.execute(select(self.model).where(self.model.id == user_id))
-        return result.scalars().first()
-
-    async def create_password_reset_token(self, session: AsyncSession, email: str) -> str:
-        """Создает токен для восстановления пароля используя JWT"""
-        # Получаем пользователя
-        user = await self.get_by_email(session, email)
-        if not user:
-            raise ValueError('Пользователь не найден')
-
-        # Используем JWT стратегию для генерации токена
-        jwt_strategy = get_jwt_strategy()
-        token = await jwt_strategy.generate_password_reset_token(str(user.id), email)
-
-        return token
-
-    async def verify_reset_token(self, session: AsyncSession, token: str) -> bool:
-        """Проверяет токен восстановления пароля используя JWT"""
-        try:
-            # Используем JWT стратегию для проверки токена
-            jwt_strategy = get_jwt_strategy()
-            payload = await jwt_strategy.verify_password_reset_token(token)
-
-            # Проверяем существование пользователя
-            user = await self.get_by_id(session, payload['sub'])
-            return user is not None
-
-        except (ValueError, KeyError):
-            return False
-
-    async def reset_password_with_token(
-        self, session: AsyncSession, token: str, new_password: str
-    ) -> bool:
-        """Сбрасывает пароль с использованием JWT токена"""
-        try:
-            # Проверяем токен и получаем payload
-            jwt_strategy = get_jwt_strategy()
-            payload = await jwt_strategy.verify_password_reset_token(token)
-
-            # Получаем пользователя
-            user = await self.get_by_id(session, payload['sub'])
-            if not user:
-                return False
-
-            # Обновляем пароль используя JWT стратегию
-            hashed_password = jwt_strategy.password_helper.hash(new_password)
-            user.hashed_password = hashed_password
-
-            await session.commit()
-            return True
-
-        except ValueError:
-            return False
-
-    async def reset_password_by_admin(
-        self, session: AsyncSession, user_id: UUID, new_password: str
-    ) -> bool:
-        """Принудительный сброс пароля администратором"""
-        try:
-            user = await self.get_or_404(session, user_id)
-
-            # Хешируем новый пароль
-            from fastapi_users.password import PasswordHelper
-
-            password_helper = PasswordHelper()
-            hashed_password = password_helper.hash(new_password)
-
-            # Обновляем пароль
-            user.hashed_password = hashed_password
-            session.add(user)
-            await session.commit()
-
-            return True
-
-        except Exception as e:
-            await session.rollback()
-            logger.error(f'Ошибка при сбросе пароля: {e}')
-            return False
-
-    def _hash_password(self, password: str) -> str:
-        """Хеширует пароль используя JWT стратегию"""
-        jwt_strategy = get_jwt_strategy()
-        return jwt_strategy.password_helper.hash(password)
-
-    async def verify_password(self, session: AsyncSession, user_id: UUID, password: str) -> bool:
-        """Проверка текущего пароля пользователя"""
-        try:
-            user = await self.get_or_404(session, user_id)
-
-            # Проверяем, что у пользователя есть хешированный пароль
-            if not user.hashed_password:
-                logger.warning('У пользователя нет хешированного пароля')
-                return False
-
-            # Используем тот же PasswordHelper, что и в менеджерах
-            from fastapi_users.password import PasswordHelper
-
-            password_helper = PasswordHelper()
-
-            try:
-                # Проверяем пароль используя правильный метод
-                is_valid, _ = password_helper.verify_and_update(password, user.hashed_password)
-                logger.debug(f'Проверка пароля для пользователя {user_id}: {is_valid}')
-                return is_valid
-
-            except Exception as verify_error:
-                logger.error(f'Ошибка при проверке пароля: {verify_error}')
-                return False
-
-        except Exception as e:
-            logger.error(f'Ошибка при проверке пароля: {e}')
-            return False
-
-    async def change_password(
-        self, session: AsyncSession, user_id: UUID, new_password: str
-    ) -> bool:
-        """Смена пароля пользователем"""
-        try:
-            logger.info(f'Начинаем смену пароля для пользователя {user_id}')
-            user = await self.get_or_404(session, user_id)
-            logger.debug(f'Пользователь найден: {user.id}')
-
-            # Используем тот же PasswordHelper, что и в менеджерах
-            from fastapi_users.password import PasswordHelper
-
-            password_helper = PasswordHelper()
-            hashed_password = password_helper.hash(new_password)
-            logger.debug(f'Новый хеш создан: {hashed_password[:20]}...')
-
-            user.hashed_password = hashed_password
-            session.add(user)
-            logger.debug('Пользователь добавлен в сессию')
-
-            await session.commit()
-            logger.info('Транзакция зафиксирована')
-
-            return True
-
-        except Exception as e:
-            await session.rollback()
-            logger.error(f'Ошибка при смене пароля: {e}')
-            logger.error(f'Тип ошибки: {type(e)}')
-            import traceback
-
-            logger.error(f'Traceback: {traceback.format_exc()}')
-            return False
-
-    async def debug_password_hash(self, session: AsyncSession, user_id: UUID) -> dict:
-        """Диагностика хеша пароля пользователя"""
-        try:
-            user = await self.get_or_404(session, user_id)
-
-            return {
-                'user_id': str(user_id),
-                'has_password': bool(user.hashed_password),
-                'hash_length': len(user.hashed_password) if user.hashed_password else 0,
-                'hash_prefix': user.hashed_password[:10] if user.hashed_password else None,
-                'is_bcrypt_format': user.hashed_password.startswith('$2b$')
-                if user.hashed_password
-                else False,
-            }
-
-        except Exception as e:
-            return {'error': str(e)}
 
 
 user_crud = CRUDUsers(CompanyUser)

--- a/src/crud/crud_user.py
+++ b/src/crud/crud_user.py
@@ -1,4 +1,5 @@
 import logging
+from uuid import UUID  # noqa: F401  # Required for CRUDPasswordMixin methods
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio.session import AsyncSession

--- a/src/features_v1/__init__.py
+++ b/src/features_v1/__init__.py
@@ -1,4 +1,5 @@
 from .company_enums.endpoints import router as company_enums_router
+from .company_moderator_auth.endpoints import router as company_moderator_auth_router
 from .company_moderator_management.endpoints import router as company_moderator_management_router
 from .company_feedback_router.endpoints import router as company_feedback_router
 from .company_problem_discussion.endpoints import router as company_problem_discussion_router
@@ -17,6 +18,7 @@ from .tabit_license_management.endpoints import router as tabit_license_manageme
 
 __all__ = [
     'company_enums_router',
+    'company_moderator_auth_router',
     'company_moderator_management_router',
     'company_feedback_router',
     'company_problem_discussion_router',

--- a/src/features_v1/company_moderator_auth/__init__.py
+++ b/src/features_v1/company_moderator_auth/__init__.py
@@ -1,0 +1,5 @@
+"""Модуль аутентификации модераторов компаний."""
+
+from src.features_v1.company_moderator_auth.endpoints import router
+
+__all__ = ['router']

--- a/src/features_v1/company_moderator_auth/endpoints.py
+++ b/src/features_v1/company_moderator_auth/endpoints.py
@@ -1,0 +1,187 @@
+"""Модуль роутеров для аутентификации модераторов компаний."""
+
+from fastapi import APIRouter, Depends, Response
+from fastapi.responses import JSONResponse
+from fastapi.security import OAuth2PasswordRequestForm
+from fastapi_users import BaseUserManager, models
+from fastapi_users.authentication import Strategy
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth.dependencies import (
+    current_company_moderator,
+    get_current_user_refresh_token,
+    get_current_user_token,
+)
+from src.core.auth.jwt import jwt_auth_backend_user
+from src.core.auth.managers import get_user_manager
+from src.core.auth.protocol import StrategyT
+from src.core.database.db_depends import get_async_session
+from src.crud import moderator_crud
+from src.features_v1.common.password_forgot_reset import (
+    PasswordForgotResetMixin,
+)
+from src.features_v1.validators import check_user_is_active
+from src.models import CompanyUser
+from src.schemas import TokenReadSchemas, UserReadSchema
+
+router = APIRouter()
+
+
+@router.post(
+    '/login',
+    response_model=TokenReadSchemas,
+    summary='Вход модератора компании',
+    description='Авторизация модератора компании в системе',
+)
+async def login(
+    credentials: OAuth2PasswordRequestForm = Depends(),
+    user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+    strategy: StrategyT[models.UP, models.ID] = Depends(jwt_auth_backend_user.get_strategy),
+) -> JSONResponse:
+    """
+    Авторизация модераторов компаний.
+
+    Параметры декоратора:
+        path: присвоен не явно. URL-путь, который будет использоваться для этой операции.
+        response_model: тип, который будет использоваться для ответа: список с Pydantic-схемами.
+        summary: краткое описание.
+        description: подробное описание.
+    Параметры функции:
+        credentials: данные возвращаемые из формы запроса.
+        user_manager: менеджер управления пользователей сервиса, вызывается через зависимости.
+        strategy: стратегия получения токена.
+    Вернет JSON, пример:
+        {
+            "access_token": "<зашифрованная строка>",
+            "refresh_token": "<зашифрованная строка>",
+            "token_type": "bearer"
+        }
+    """
+    user = await user_manager.authenticate(credentials)
+    check_user_is_active(user)
+
+    # Проверяем, что пользователь является модератором
+    from src.models import CompanyUserRole
+
+    if user.role != CompanyUserRole.MODERATOR:
+        from http import HTTPStatus
+
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN, detail='Доступ только для модераторов компаний'
+        )
+
+    return await jwt_auth_backend_user.login_with_refresh(strategy, user)  # type: ignore[misc]
+
+
+@router.post(
+    '/logout',
+    summary='Выход модератора компании',
+    description='Выход модератора компании из системы',
+)
+async def logout(
+    user_token: tuple[models.UP, str] = Depends(get_current_user_token),
+    strategy: Strategy[models.UP, models.ID] = Depends(jwt_auth_backend_user.get_strategy),
+) -> Response:
+    """
+    Выход из системы модераторов компаний.
+
+    Параметры декоратора:
+        path: присвоен не явно. URL-путь, который будет использоваться для этой операции.
+        summary: краткое описание.
+        description: подробное описание.
+    Параметры функции:
+        user_and_access_token: получение пользователя и его access-токена через зависимость из
+            данных запроса.
+        strategy: стратегия получения токена.
+    """
+    user, token = user_token
+    return await jwt_auth_backend_user.logout(strategy, user, token)
+
+
+@router.post(
+    '/refresh-token',
+    response_model=TokenReadSchemas,
+    summary='Обновление токена модератора компании',
+    description='Обновление токенов для модератора компании',
+)
+async def refresh_token_moderator(
+    user_and_refresh_token: tuple[CompanyUser, str] = Depends(get_current_user_refresh_token),
+    strategy: StrategyT[models.UP, models.ID] = Depends(jwt_auth_backend_user.get_strategy),
+) -> JSONResponse:
+    """
+    Обновление токенов для модератора компании.
+    response_model: тип, который будет использоваться для ответа: список с Pydantic-схемами.
+    В заголовке Authorization принимает refresh-token, возвращает обновленные
+    access-token и refresh-token.
+    Доступно только модераторам компаний.
+
+    Параметры декоратора:
+        path: присвоен не явно. URL-путь, который будет использоваться для этой операции.
+        summary: краткое описание.
+        description: подробное описание.
+    Параметры функции:
+        user_and_refresh_token: получение пользователя и его refresh-токена через зависимость из
+            данных запроса.
+        strategy: стратегия получения токена.
+    Вернет JSON, пример:
+        {
+            "access_token": "<зашифрованная строка>",
+            "refresh_token": "<зашифрованная строка>",
+            "token_type": "bearer"
+        }
+    """
+    user, _ = user_and_refresh_token
+    check_user_is_active(user)
+
+    # Проверяем, что пользователь является модератором
+    from src.models import CompanyUserRole
+
+    if user.role != CompanyUserRole.MODERATOR:
+        from http import HTTPStatus
+
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN, detail='Доступ только для модераторов компаний'
+        )
+
+    return await jwt_auth_backend_user.login_with_refresh(strategy, user)  # type: ignore[misc]
+
+
+@router.get(
+    '/me',
+    response_model=UserReadSchema,
+    summary='Получить информацию о себе',
+    description='Получение информации о текущем модераторе компании',
+)
+async def get_me_moderator(
+    session: AsyncSession = Depends(get_async_session),
+    user: CompanyUser = Depends(current_company_moderator),
+) -> UserReadSchema:
+    """
+    Для доступа к своей учетной записи модератора компании.
+    Доступно только хозяину учетной записи.
+
+    Параметры декоратора:
+        path: присвоен не явно. URL-путь, который будет использоваться для этой операции.
+        response_model: тип, который будет использоваться для ответа: список с Pydantic-схемами.
+        summary: краткое описание.
+        description: подробное описание.
+    Параметры функции:
+        session: асинхронная сессия через зависимость.
+        user: получение пользователя через зависимости.
+    """
+    return await moderator_crud.get_or_404(session, user.id)
+
+
+# Создаем экземпляр миксина для модераторов компаний
+moderator_password_forgot_reset = PasswordForgotResetMixin()
+moderator_password_forgot_reset.create_password_forgot_reset_routes(
+    router,
+    crud=moderator_crud,
+    current_user_dependency=current_company_moderator,
+    user_type_name='модератора',
+    prefix='',
+)

--- a/tests/test_companies.py
+++ b/tests/test_companies.py
@@ -81,9 +81,9 @@ class TestGetСompanies:
         response = await client.get(
             UrlConstants.COMPANY_ENDPOINT.format(company_slug=company.slug), headers=token
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.COMPANY_FIELDS, (
             f'Ожидались поля {ExpectedFieldsConstants.COMPANY_FIELDS}, '
@@ -96,9 +96,9 @@ class TestGetСompanies:
         }
 
         for field, expected_value in field_checks.items():
-            assert (
-                data[field] == expected_value
-            ), f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            assert data[field] == expected_value, (
+                f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            )
 
 
 class TestGetEmployees:
@@ -127,16 +127,16 @@ class TestGetEmployees:
         response = await client.get(
             UrlConstants.EMPLOYEES_ENDPOINT.format(company_slug=company.slug), headers=token
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
 
         assert isinstance(data, list), f'Ожидался список, получен тип {type(data)}'
-        assert len(data) == len(
-            employees
-        ), f'Ожидалось {len(employees)} сотрудников, получено {len(data)}'
+        assert len(data) == len(employees), (
+            f'Ожидалось {len(employees)} сотрудников, получено {len(data)}'
+        )
 
         for employee_data in data:
             assert set(employee_data.keys()) == ExpectedFieldsConstants.EMPLOYEE_FIELDS, (
@@ -184,30 +184,30 @@ class TestGetEmployee:
             ),
             headers=token,
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.EMPLOYEE_FIELDS, (
             f'Ожидались поля {ExpectedFieldsConstants.EMPLOYEE_FIELDS}, '
             f'получены поля {set(data.keys())}'
         )
-        assert data['id'] == str(
-            employee.id
-        ), f'Ожидался id сотрудника {employee.id}, получен {data["id"]}'
-        assert (
-            data['email'] == employee.email
-        ), f'Ожидался email сотрудника "{employee.email}", получен "{data["email"]}"'
-        assert (
-            data['name'] == employee.name
-        ), f'Ожидалось имя сотрудника "{employee.name}", получено "{data["name"]}"'
-        assert (
-            data['surname'] == employee.surname
-        ), f'Ожидалась фамилия сотрудника "{employee.surname}", получена "{data["surname"]}"'
-        assert (
-            data['company_id'] == company.id
-        ), f'Ожидался company_id {company.id}, получен {data["company_id"]}'
+        assert data['id'] == str(employee.id), (
+            f'Ожидался id сотрудника {employee.id}, получен {data["id"]}'
+        )
+        assert data['email'] == employee.email, (
+            f'Ожидался email сотрудника "{employee.email}", получен "{data["email"]}"'
+        )
+        assert data['name'] == employee.name, (
+            f'Ожидалось имя сотрудника "{employee.name}", получено "{data["name"]}"'
+        )
+        assert data['surname'] == employee.surname, (
+            f'Ожидалась фамилия сотрудника "{employee.surname}", получена "{data["surname"]}"'
+        )
+        assert data['company_id'] == company.id, (
+            f'Ожидался company_id {company.id}, получен {data["company_id"]}'
+        )
 
 
 class TestPatchEmployee:
@@ -275,9 +275,9 @@ class TestPatchEmployee:
             headers=token,
             json={field: new_value},
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.EMPLOYEE_FIELDS, (
@@ -285,9 +285,9 @@ class TestPatchEmployee:
             f'получены поля {set(data.keys())}'
         )
 
-        assert (
-            data[field] == new_value
-        ), f"Ожидалось новое значение поля '{field}': '{new_value}', получено: '{data[field]}'"
+        assert data[field] == new_value, (
+            f"Ожидалось новое значение поля '{field}': '{new_value}', получено: '{data[field]}'"
+        )
 
         for key, value in old_data.items():
             if key != field and key not in ('updated_at', 'created_at'):
@@ -331,9 +331,9 @@ class TestPatchEmployee:
             headers=token,
             json=update_data,
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.EMPLOYEE_FIELDS, (
@@ -534,24 +534,24 @@ class TestGetDepartments:
         response = await client.get(
             UrlConstants.DEPARTMENTS_ENDPOINT.format(company_slug=company.slug), headers=token
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
 
         assert isinstance(data, list), f'Ожидался список, получен тип {type(data)}'
-        assert len(data) == len(
-            departments
-        ), f'Ожидалось {len(departments)} департаментов, получено {len(data)}'
+        assert len(data) == len(departments), (
+            f'Ожидалось {len(departments)} департаментов, получено {len(data)}'
+        )
         for dept in data:
             assert set(dept.keys()) == ExpectedFieldsConstants.DEPARTMENT_FIELDS, (
                 f'Ожидались поля {ExpectedFieldsConstants.DEPARTMENT_FIELDS}, '
                 f'получены поля {set(dept.keys())}'
             )
-            assert (
-                dept['company_id'] == company.id
-            ), f'Ожидался company_id {company.id}, получен {dept["company_id"]}'
+            assert dept['company_id'] == company.id, (
+                f'Ожидался company_id {company.id}, получен {dept["company_id"]}'
+            )
 
 
 class TestGetDepartment:
@@ -580,9 +580,9 @@ class TestGetDepartment:
             ),
             headers=token,
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.DEPARTMENT_FIELDS, (
@@ -598,9 +598,9 @@ class TestGetDepartment:
         }
 
         for field, expected_value in field_checks.items():
-            assert (
-                data[field] == expected_value
-            ), f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            assert data[field] == expected_value, (
+                f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            )
 
 
 class TestPatchDepartment:
@@ -632,9 +632,9 @@ class TestPatchDepartment:
             headers=token,
             json={'name': new_name},
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.DEPARTMENT_FIELDS, (
@@ -642,16 +642,16 @@ class TestPatchDepartment:
             f'получены поля {set(data.keys())}'
         )
 
-        assert (
-            data['name'] == new_name
-        ), f"Ожидалось новое имя '{new_name}', получено: '{data['name']}'"
+        assert data['name'] == new_name, (
+            f"Ожидалось новое имя '{new_name}', получено: '{data['name']}'"
+        )
 
         field_checks = {'id': department.id, 'company_id': company.id}
 
         for field, expected_value in field_checks.items():
-            assert (
-                data[field] == expected_value
-            ), f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            assert data[field] == expected_value, (
+                f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            )
 
     @pytest.mark.asyncio
     async def test_patch_department_not_found(
@@ -787,9 +787,9 @@ class TestCreateDepartment:
             headers=token,
             json=department_data,
         )
-        assert (
-            response.status_code == status.HTTP_201_CREATED
-        ), f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.DEPARTMENT_FIELDS, (
@@ -803,12 +803,12 @@ class TestCreateDepartment:
         }
 
         for field, expected_value in field_checks.items():
-            assert (
-                data[field] == expected_value
-            ), f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
-        assert isinstance(
-            data['id'], int
-        ), f'Ожидался целочисленный id, получен тип {type(data["id"])}'
+            assert data[field] == expected_value, (
+                f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            )
+        assert isinstance(data['id'], int), (
+            f'Ожидался целочисленный id, получен тип {type(data["id"])}'
+        )
 
     @pytest.mark.asyncio
     async def test_create_department_with_all_fields(
@@ -833,9 +833,9 @@ class TestCreateDepartment:
             headers=token,
             json=department_data,
         )
-        assert (
-            response.status_code == status.HTTP_201_CREATED
-        ), f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.DEPARTMENT_FIELDS, (
@@ -846,12 +846,12 @@ class TestCreateDepartment:
         field_checks = {'name': department_data['name'], 'company_id': company.id}
 
         for field, expected_value in field_checks.items():
-            assert (
-                data[field] == expected_value
-            ), f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
-        assert isinstance(
-            data['id'], int
-        ), f'Ожидался целочисленный id, получен тип {type(data["id"])}'
+            assert data[field] == expected_value, (
+                f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            )
+        assert isinstance(data['id'], int), (
+            f'Ожидался целочисленный id, получен тип {type(data["id"])}'
+        )
 
 
 class TestCreateEmployee:
@@ -882,9 +882,9 @@ class TestCreateEmployee:
             headers=token,
             json=employee_data,
         )
-        assert (
-            response.status_code == status.HTTP_201_CREATED
-        ), f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.EMPLOYEE_FIELDS, (
@@ -901,9 +901,9 @@ class TestCreateEmployee:
         }
 
         for field, expected_value in required_fields.items():
-            assert (
-                data[field] == expected_value
-            ), f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            assert data[field] == expected_value, (
+                f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            )
 
     @pytest.mark.asyncio
     async def test_create_employee_with_all_fields(
@@ -932,9 +932,9 @@ class TestCreateEmployee:
             headers=token,
             json=employee_data,
         )
-        assert (
-            response.status_code == status.HTTP_201_CREATED
-        ), f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f'Ожидался статус 201 Created, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert set(data.keys()) == ExpectedFieldsConstants.EMPLOYEE_FIELDS, (
@@ -964,9 +964,9 @@ class TestCreateEmployee:
         }
 
         for field, expected_value in field_checks.items():
-            assert (
-                data[field] == expected_value
-            ), f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            assert data[field] == expected_value, (
+                f"Ожидалось значение поля '{field}': '{expected_value}', получено: '{data[field]}'"
+            )
 
     @pytest.mark.asyncio
     async def test_create_employees_with_same_telegram(
@@ -1042,9 +1042,9 @@ class TestFeedback:
             headers=token,
             json=feedback_data,
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'Ожидался статус 200 OK, получен {response.status_code}. Ответ: {response.text}'
+        )
 
         data = response.json()
         assert isinstance(data, dict), f'Ожидался словарь, получен тип {type(data)}'

--- a/tests/test_company_user_auth.py
+++ b/tests/test_company_user_auth.py
@@ -31,9 +31,9 @@ class TestLoginUser:
         """Тест на вход в систему пользователей сервиса с валидными данными."""
         login_payload = {'username': user.email, 'password': AuthDataConstants.GOOD_PASSWORD}
         response = await client.post(UrlConstants.USER_LOGIN, data=login_payload)
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'При авторизации {text} у ответа должен быть статус 200:\n{response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'При авторизации {text} у ответа должен быть статус 200:\n{response.text}'
+        )
         result = response.json()
         for key in ('access_token', 'refresh_token', 'token_type'):
             assert key in result, f'В теле ответа нет ключа {key}'
@@ -54,9 +54,9 @@ class TestLoginUser:
         """
         login_payload = {'username': user.email, 'password': AuthDataConstants.GOOD_PASSWORD}
         response = await client.post(UrlConstants.USER_LOGIN, data=login_payload)
-        assert (
-            response.status_code == status.HTTP_400_BAD_REQUEST
-        ), f'При авторизации {text} у ответа должен быть статус 400:\n{response.text}'
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+            f'При авторизации {text} у ответа должен быть статус 400:\n{response.text}'
+        )
         result = response.json()
         assert 'detail' in result, 'В теле ответа с ошибкой нет ключа detail'
 
@@ -76,9 +76,9 @@ class TestLoginUser:
         )
         for bad_login_payload in bad_login_payloads:
             response = await client.post(UrlConstants.ADMIN_LOGIN, data=bad_login_payload)
-            assert (
-                response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-            ), f'Не корректный ответ с данными\n{bad_login_payload}\n{response.text}'
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, (
+                f'Не корректный ответ с данными\n{bad_login_payload}\n{response.text}'
+            )
             result = response.json()
             assert 'detail' in result, 'В теле ответа с ошибкой нет ключа detail'
 
@@ -90,9 +90,9 @@ class TestLoginUser:
             'password': f'NOT {AuthDataConstants.GOOD_PASSWORD}',
         }
         response = await client.post(UrlConstants.ADMIN_LOGIN, data=login_payload)
-        assert (
-            response.status_code == status.HTTP_400_BAD_REQUEST
-        ), f'Не корректный ответ с данными\n{login_payload}\n{response.text}'
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+            f'Не корректный ответ с данными\n{login_payload}\n{response.text}'
+        )
         result = response.json()
         assert 'detail' in result, 'В теле ответа с ошибкой нет ключа detail'
 
@@ -115,9 +115,9 @@ class TestLogoutUser:
     async def test_logout_user(self, client: AsyncClient, token, text):
         """Тест на выход из системы пользователей сервиса."""
         response = await client.post(UrlConstants.USER_LOGOUT, headers=token)
-        assert (
-            response.status_code == status.HTTP_204_NO_CONTENT
-        ), f'При выходе из системы {text} должен быть статус ответа 204:\n{response.text}'
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f'При выходе из системы {text} должен быть статус ответа 204:\n{response.text}'
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -131,9 +131,9 @@ class TestLogoutUser:
     async def test_logout_user_not_access(self, client: AsyncClient, token, text):
         """Тест на выход из системы пользователей сервиса."""
         response = await client.post(UrlConstants.USER_LOGOUT, headers=token)
-        assert (
-            response.status_code == status.HTTP_401_UNAUTHORIZED
-        ), f'При выходе из системы {text} должен быть статус ответа 401:\n{response.text}'
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, (
+            f'При выходе из системы {text} должен быть статус ответа 401:\n{response.text}'
+        )
 
 
 class TestRefreshTokenUser:
@@ -159,9 +159,9 @@ class TestRefreshTokenUser:
     ):
         """Тест получения нового токена по refresh-token для пользователя сервиса Tabit."""
         response = await client.post(UrlConstants.USER_REFRESH, headers=token)
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'При получение токена {text} у ответа должен быть статус 200:\n{response.text}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'При получение токена {text} у ответа должен быть статус 200:\n{response.text}'
+        )
         result = response.json()
         for key in ('access_token', 'refresh_token', 'token_type'):
             assert key in result, f'В теле ответа нет ключа {key}'
@@ -270,13 +270,13 @@ class TestGetMeUser:
                 f'Значение ключа {key} не должно быть пустым или быть null при запросе {text}:'
                 f'\n{data}'
             )
-        assert (
-            data['role'] == role
-        ), f'Роль пользователя {role} не соответствует роли в ответе: {data["role"]}'
+        assert data['role'] == role, (
+            f'Роль пользователя {role} не соответствует роли в ответе: {data["role"]}'
+        )
         for key in ('password', 'hashed_password'):
-            assert (
-                key not in data
-            ), f'Значение ключа {key} не должно быть в теле ответа при запросе {text}:\n{data}'
+            assert key not in data, (
+                f'Значение ключа {key} не должно быть в теле ответа при запросе {text}:\n{data}'
+            )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -357,13 +357,13 @@ class TestPatchMeUser:
         data_after = response_patch.json()
         for key in data_before:
             if key in payload:
-                assert (
-                    data_after[key] == payload[key]
-                ), f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                assert data_after[key] == payload[key], (
+                    f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                )
             elif key == 'updated_at':
-                assert (
-                    data_after[key] != data_before[key]
-                ), f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                assert data_after[key] != data_before[key], (
+                    f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                )
             else:
                 assert data_after[key] == data_before[key], (
                     f'При изменение своих личных данных {text} значение {key} поменялось, '

--- a/tests/test_problem_feeds.py
+++ b/tests/test_problem_feeds.py
@@ -32,15 +32,15 @@ class TestGetProblemFeed:
             headers=token,
         )
 
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
 
         result = response.json()
         assert isinstance(result, list)
-        assert len(result) == len(
-            message_feeds
-        ), f'Длина полученного списка должна быть равна {len(message_feeds)}'
+        assert len(result) == len(message_feeds), (
+            f'Длина полученного списка должна быть равна {len(message_feeds)}'
+        )
 
     async def test_get_message_feeds_of_another_company(
         self, client, employee_of_company, get_token_for_user, message_feed_for_test
@@ -88,14 +88,14 @@ class TestGetProblemFeed:
         )
 
         result = response.json()
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
 
         assert isinstance(result, list)
-        assert len(result) == len(
-            comments
-        ), f'Длина полученного списка должна быть равна {len(comments)}'
+        assert len(result) == len(comments), (
+            f'Длина полученного списка должна быть равна {len(comments)}'
+        )
 
     async def test_get_feed_comments_of_another_company(
         self, client, employee_of_company, get_token_for_user, comment_for_test
@@ -162,18 +162,18 @@ class TestPostProblemFeed:
         )
 
         result = response.json()
-        assert (
-            result['text'] == payload['text']
-        ), 'Значение поля "text" созданного объекта не соответствует ожидаемому значению.'
-        assert (
-            result['important'] == expected_result
-        ), 'Значение поля "important" созданного объекта не соответствует ожидаемому значению.'
-        assert result['owner_id'] == str(
-            employee.id
-        ), 'Значение поля "owner_id" созданного объекта не соответствует ожидаемому значению.'
-        assert (
-            result['problem_id'] == problem.id
-        ), 'Значение поля "problem_id" созданного объекта не соответствует ожидаемому значению.'
+        assert result['text'] == payload['text'], (
+            'Значение поля "text" созданного объекта не соответствует ожидаемому значению.'
+        )
+        assert result['important'] == expected_result, (
+            'Значение поля "important" созданного объекта не соответствует ожидаемому значению.'
+        )
+        assert result['owner_id'] == str(employee.id), (
+            'Значение поля "owner_id" созданного объекта не соответствует ожидаемому значению.'
+        )
+        assert result['problem_id'] == problem.id, (
+            'Значение поля "problem_id" созданного объекта не соответствует ожидаемому значению.'
+        )
 
     @pytest.mark.parametrize(
         'payload, expected_result', ProblemFeedsDataConstants.MESSAGE_FEED_CREATE_BAD
@@ -191,9 +191,9 @@ class TestPostProblemFeed:
             json=payload,
         )
 
-        assert (
-            response.status_code == expected_result
-        ), f'В ответе ожидается status_code {expected_result}, получен {response.status_code}'
+        assert response.status_code == expected_result, (
+            f'В ответе ожидается status_code {expected_result}, получен {response.status_code}'
+        )
 
     async def test_create_message_feed_with_mismatched_company_slug(
         self, client, employee_of_company, get_token_for_user, problem_for_test
@@ -265,16 +265,16 @@ class TestPostProblemFeed:
         )
 
         result = response.json()
-        assert (
-            result['text'] == ProblemFeedsDataConstants.COMMENT_CREATE_NEW['text']
-        ), 'Значение поля "text" созданного объекта не соответствует ожидаемому значению.'
+        assert result['text'] == ProblemFeedsDataConstants.COMMENT_CREATE_NEW['text'], (
+            'Значение поля "text" созданного объекта не соответствует ожидаемому значению.'
+        )
         assert result['rating'] == 0, 'Рейтинг нового комментария должен быть равен 0'
-        assert result['owner_id'] == str(
-            employee.id
-        ), 'Значение поля "owner_id" созданного объекта не соответствует ожидаемому значению.'
-        assert (
-            result['message_id'] == message_feed.id
-        ), 'Значение поля "message_id" созданного объекта не соответствует ожидаемому значению.'
+        assert result['owner_id'] == str(employee.id), (
+            'Значение поля "owner_id" созданного объекта не соответствует ожидаемому значению.'
+        )
+        assert result['message_id'] == message_feed.id, (
+            'Значение поля "message_id" созданного объекта не соответствует ожидаемому значению.'
+        )
 
     @pytest.mark.parametrize(
         'payload, expected_result', ProblemFeedsDataConstants.COMMENT_CREATE_BAD
@@ -296,9 +296,9 @@ class TestPostProblemFeed:
             json=payload,
         )
 
-        assert (
-            response.status_code == expected_result
-        ), f'В ответе ожидается status_code {expected_result}, получен {response.status_code}'
+        assert response.status_code == expected_result, (
+            f'В ответе ожидается status_code {expected_result}, получен {response.status_code}'
+        )
 
     async def test_create_comment_for_wrong_message_feed(
         self, client, get_token_for_user, message_feed_for_test
@@ -342,21 +342,21 @@ class TestPostProblemFeed:
             headers=another_user_token,
         )
 
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
 
         comment = await async_session.merge(comment)
         await async_session.refresh(comment)
         association_obj = await get_association_objects_iterator(
             async_session, AssociationUserComment, another_user.id, comment.id
         )
-        assert (
-            comment.rating == 1
-        ), 'Рейтинг комментария должен был увеличиться на 1 (стать равным 1)'
-        assert (
-            association_obj.scalar_one_or_none() is not None
-        ), 'При лайке комментария в ассоциативной таблице должна появиться связанная запись'
+        assert comment.rating == 1, (
+            'Рейтинг комментария должен был увеличиться на 1 (стать равным 1)'
+        )
+        assert association_obj.scalar_one_or_none() is not None, (
+            'При лайке комментария в ассоциативной таблице должна появиться связанная запись'
+        )
 
     async def test_successful_comment_unlike(
         self, async_session, client, employee_of_company, get_token_for_user, comment_for_test
@@ -382,15 +382,15 @@ class TestPostProblemFeed:
             headers=another_user_token,
         )
 
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
 
         comment = await async_session.merge(comment)
         await async_session.refresh(comment)
-        assert (
-            comment.rating == old_rating - 1
-        ), 'Рейтинг комментария должен был уменьшиться на 1 (стать равным 0)'
+        assert comment.rating == old_rating - 1, (
+            'Рейтинг комментария должен был уменьшиться на 1 (стать равным 0)'
+        )
 
     async def test_unsuccessful_comment_like_by_author(
         self, client, get_token_for_user, comment_for_test
@@ -412,9 +412,9 @@ class TestPostProblemFeed:
             f'получен {response.status_code}'
         )
 
-        assert (
-            comment.rating == old_rating
-        ), 'Рейтинг комментария не должен меняться при неуспешном лайке.'
+        assert comment.rating == old_rating, (
+            'Рейтинг комментария не должен меняться при неуспешном лайке.'
+        )
 
     async def test_unsuccessful_repeated_comment_like(
         self, client, employee_of_company, get_token_for_user, comment_for_test
@@ -581,23 +581,23 @@ class TestPatchProblemFeed:
             json=ProblemFeedsDataConstants.COMMENT_UPDATE,
         )
 
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
 
         result = response.json()
-        assert (
-            result['text'] == ProblemFeedsDataConstants.COMMENT_UPDATE['text']
-        ), 'Значение поля "text" обновлённого объекта не соответствует ожидаемому значению.'
-        assert (
-            result['rating'] == comment.rating
-        ), 'Рейтинг обновлённого комментария должен меняться'
-        assert result['owner_id'] == str(
-            comment.owner_id
-        ), 'Значение поля "owner_id" обновлённого объекта не соответствует ожидаемому значению.'
-        assert (
-            result['message_id'] == comment.message_id
-        ), 'Значение поля "message_id" обновлённого объекта не соответствует ожидаемому значению.'
+        assert result['text'] == ProblemFeedsDataConstants.COMMENT_UPDATE['text'], (
+            'Значение поля "text" обновлённого объекта не соответствует ожидаемому значению.'
+        )
+        assert result['rating'] == comment.rating, (
+            'Рейтинг обновлённого комментария должен меняться'
+        )
+        assert result['owner_id'] == str(comment.owner_id), (
+            'Значение поля "owner_id" обновлённого объекта не соответствует ожидаемому значению.'
+        )
+        assert result['message_id'] == comment.message_id, (
+            'Значение поля "message_id" обновлённого объекта не соответствует ожидаемому значению.'
+        )
 
     @pytest.mark.parametrize(
         'payload, expected_result', ProblemFeedsDataConstants.COMMENT_UPDATE_BAD
@@ -619,9 +619,9 @@ class TestPatchProblemFeed:
             json=payload,
         )
 
-        assert (
-            response.status_code == expected_result
-        ), f'В ответе ожидается status_code {expected_result}, получен {response.status_code}'
+        assert response.status_code == expected_result, (
+            f'В ответе ожидается status_code {expected_result}, получен {response.status_code}'
+        )
 
     async def test_patch_comment_wrong_owner(
         self, client, employee_of_company, get_token_for_user, comment_for_test

--- a/tests/test_tabit_admin_auth.py
+++ b/tests/test_tabit_admin_auth.py
@@ -26,9 +26,9 @@ class TestLoginAdminTabit:
                 'password': AuthDataConstants.GOOD_PASSWORD,
             }
             response = await client.post(UrlConstants.ADMIN_LOGIN, data=login_payload)
-            assert (
-                response.status_code == status.HTTP_200_OK
-            ), f'При авторизации {text} у ответа должен быть статус 200:\n{response.text}'
+            assert response.status_code == status.HTTP_200_OK, (
+                f'При авторизации {text} у ответа должен быть статус 200:\n{response.text}'
+            )
             result = response.json()
             for key in ('access_token', 'refresh_token', 'token_type'):
                 assert key in result, f'В теле ответа нет ключа {key}'
@@ -52,9 +52,9 @@ class TestLoginAdminTabit:
                 'password': AuthDataConstants.GOOD_PASSWORD,
             }
             response = await client.post(UrlConstants.ADMIN_LOGIN, data=login_payload)
-            assert (
-                response.status_code == status.HTTP_400_BAD_REQUEST
-            ), f'При авторизации {text} у ответа должен быть статус 400:\n{response.text}'
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+                f'При авторизации {text} у ответа должен быть статус 400:\n{response.text}'
+            )
             result = response.json()
             assert 'detail' in result, 'В теле ответа с ошибкой нет ключа detail'
 
@@ -74,9 +74,9 @@ class TestLoginAdminTabit:
         )
         for bad_login_payload in bad_login_payloads:
             response = await client.post(UrlConstants.ADMIN_LOGIN, data=bad_login_payload)
-            assert (
-                response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-            ), f'Не корректный ответ с данными\n{bad_login_payload}\n{response.text}'
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, (
+                f'Не корректный ответ с данными\n{bad_login_payload}\n{response.text}'
+            )
             result = response.json()
             assert 'detail' in result, 'В теле ответа с ошибкой нет ключа detail'
 
@@ -88,9 +88,9 @@ class TestLoginAdminTabit:
             'password': f'NOT {AuthDataConstants.GOOD_PASSWORD}',
         }
         response = await client.post(UrlConstants.ADMIN_LOGIN, data=login_payload)
-        assert (
-            response.status_code == status.HTTP_400_BAD_REQUEST
-        ), f'Не корректный ответ с данными\n{login_payload}\n{response.text}'
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+            f'Не корректный ответ с данными\n{login_payload}\n{response.text}'
+        )
         result = response.json()
         assert 'detail' in result, 'В теле ответа с ошибкой нет ключа detail'
 
@@ -111,9 +111,9 @@ class TestLogoutAdminTabit:
         )
         for token, text in variants:
             response = await client.post(UrlConstants.ADMIN_LOGOUT, headers=token)
-            assert (
-                response.status_code == status.HTTP_204_NO_CONTENT
-            ), f'При выходе из системы {text} должен быть статус ответа 204:\n{response.text}'
+            assert response.status_code == status.HTTP_204_NO_CONTENT, (
+                f'При выходе из системы {text} должен быть статус ответа 204:\n{response.text}'
+            )
 
     @pytest.mark.asyncio
     async def test_logout_admin_not_access(
@@ -130,9 +130,9 @@ class TestLogoutAdminTabit:
         )
         for token, text in variants:
             response = await client.post(UrlConstants.ADMIN_LOGOUT, headers=token)
-            assert (
-                response.status_code == status.HTTP_401_UNAUTHORIZED
-            ), f'При выходе из системы {text} должен быть статус ответа 401:\n{response.text}'
+            assert response.status_code == status.HTTP_401_UNAUTHORIZED, (
+                f'При выходе из системы {text} должен быть статус ответа 401:\n{response.text}'
+            )
 
 
 class TestCreateAdminTabit:
@@ -181,13 +181,13 @@ class TestCreateAdminTabit:
         assert is_valid_uuid(data['id']), 'Поле id не является uuid.'
         for key in data:
             if key in payload:
-                assert (
-                    data[key] == payload[key]
-                ), f'Значение ключа {key} не соответствует переданному.'
+                assert data[key] == payload[key], (
+                    f'Значение ключа {key} не соответствует переданному.'
+                )
             elif key in ('id', 'created_at', 'updated_at'):
-                assert (
-                    data[key] is not None
-                ), f'Значение ключа {key} не должно быть пустым или null.'
+                assert data[key] is not None, (
+                    f'Значение ключа {key} не должно быть пустым или null.'
+                )
             else:
                 assert data[key] is None, f'Значение ключа {key} должно быть пустым или null.'
 
@@ -363,13 +363,13 @@ class TestGetAdminTabit:
             'updated_at',
         ):
             assert key in data_row, f'Ключа {key} нет в теле ответа:\n{data_row}'
-            assert (
-                data_row[key] if key not in ('patronymic', 'phone_number') else True
-            ), f'Значение ключа {key} не должно быть пустым или быть null:\n{data_row}'
+            assert data_row[key] if key not in ('patronymic', 'phone_number') else True, (
+                f'Значение ключа {key} не должно быть пустым или быть null:\n{data_row}'
+            )
         for key in ('password', 'hashed_password', 'is_active', 'is_superuser', 'is_verified'):
-            assert (
-                key not in data_row
-            ), f'Значение ключа {key} не должно быть в теле ответа:\n{data_row}'
+            assert key not in data_row, (
+                f'Значение ключа {key} не должно быть в теле ответа:\n{data_row}'
+            )
 
     @pytest.mark.asyncio
     async def test_get_admin_not_access(
@@ -509,13 +509,13 @@ class TestPatchMeAdminTabit:
             data_after = response_patch.json()
             for key in data_before:
                 if key in payload:
-                    assert (
-                        data_after[key] == payload[key]
-                    ), f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                    assert data_after[key] == payload[key], (
+                        f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                    )
                 elif key == 'updated_at':
-                    assert (
-                        data_after[key] != data_before[key]
-                    ), f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                    assert data_after[key] != data_before[key], (
+                        f'При изменение своих личных данных {text} значение {key} не поменялось.'
+                    )
                 else:
                     assert data_after[key] == data_before[key], (
                         f'При изменение своих личных данных {text} значение {key} поменялось, '
@@ -669,13 +669,13 @@ class TestPatchIdAdminTabit:
             data_after = response_patch.json()
             for key in data_before:
                 if key in payload:
-                    assert (
-                        data_after[key] == payload[key]
-                    ), f'При изменение данных {text} по его id значение {key} не поменялось.'
+                    assert data_after[key] == payload[key], (
+                        f'При изменение данных {text} по его id значение {key} не поменялось.'
+                    )
                 elif key == 'updated_at':
-                    assert (
-                        data_after[key] != data_before[key]
-                    ), f'При изменение данных {text} по его id значение {key} не поменялось.'
+                    assert data_after[key] != data_before[key], (
+                        f'При изменение данных {text} по его id значение {key} не поменялось.'
+                    )
                 else:
                     assert data_after[key] == data_before[key], (
                         f'При изменение данных {text} по его id значение {key} поменялось, '
@@ -746,9 +746,9 @@ class TestDeleteIdAdminTabit:
             url,
             headers=superuser_token,
         )
-        assert (
-            response_get.status_code == status.HTTP_404_NOT_FOUND
-        ), f'Возможно, администратор сервиса не был удален из базы данных:\n{response_get.text}'
+        assert response_get.status_code == status.HTTP_404_NOT_FOUND, (
+            f'Возможно, администратор сервиса не был удален из базы данных:\n{response_get.text}'
+        )
 
     @pytest.mark.asyncio
     async def test_not_delete_id_superuser(
@@ -812,9 +812,9 @@ class TestDeleteIdAdminTabit:
                 url,
                 headers=superuser_token,
             )
-            assert (
-                response_get.status_code == status.HTTP_200_OK
-            ), f'Возможно, администратор сервиса был удален из базы данных:\n{response_get.text}'
+            assert response_get.status_code == status.HTTP_200_OK, (
+                f'Возможно, администратор сервиса был удален из базы данных:\n{response_get.text}'
+            )
 
 
 class TestRefreshTokenAdminTabit:
@@ -838,9 +838,9 @@ class TestRefreshTokenAdminTabit:
         )
         for token, text in variants:
             response = await client.post(UrlConstants.ADMIN_REFRESH, headers=token)
-            assert (
-                response.status_code == status.HTTP_200_OK
-            ), f'При получение токена {text} у ответа должен быть статус 200:\n{response.text}'
+            assert response.status_code == status.HTTP_200_OK, (
+                f'При получение токена {text} у ответа должен быть статус 200:\n{response.text}'
+            )
             result = response.json()
             for key in ('access_token', 'refresh_token', 'token_type'):
                 assert key in result, f'В теле ответа нет ключа {key}'

--- a/tests/test_tabit_management_department.py
+++ b/tests/test_tabit_management_department.py
@@ -369,9 +369,10 @@ class TestGetDepartment:
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert ExpectedFieldsConstants.DEPARTMENT_FIELDS_FOR_ADMIN.issubset(
-            data
-        ), f'Компания должна содержать поля: {ExpectedFieldsConstants.DEPARTMENT_FIELDS_FOR_ADMIN}'
+        assert ExpectedFieldsConstants.DEPARTMENT_FIELDS_FOR_ADMIN.issubset(data), (
+            f'Компания должна содержать поля: '
+            f'{ExpectedFieldsConstants.DEPARTMENT_FIELDS_FOR_ADMIN}'
+        )
 
     async def test_get_department_access(
         self,

--- a/tests/test_tabit_management_staff.py
+++ b/tests/test_tabit_management_staff.py
@@ -17,16 +17,16 @@ class TestGetTabitManagement:
         """Тест для проверки получения списка компаний."""
         ten_companies = [await company_for_test() for _ in range(10)]
         response = await client.get(UrlConstants.ADMIN_GET_COMPANIES, headers=admin_token)
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
         result = response.json()
-        assert isinstance(
-            result, list
-        ), f'В качестве ответа должен быть получен list, пришёл {type(result)}'
-        assert len(result) == len(
-            ten_companies
-        ), f'Длина полученного списка должна быть равна {len(ten_companies)}'
+        assert isinstance(result, list), (
+            f'В качестве ответа должен быть получен list, пришёл {type(result)}'
+        )
+        assert len(result) == len(ten_companies), (
+            f'Длина полученного списка должна быть равна {len(ten_companies)}'
+        )
 
     @pytest.mark.skip(reason='Нет возможности протестировать')
     async def test_get_paginated_companies_info(
@@ -52,16 +52,16 @@ class TestGetTabitManagement:
             for _ in range(10)
         ]
         response = await client.get(UrlConstants.ADMIN_MODS_URL, headers=admin_token)
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
         result = response.json()
-        assert isinstance(
-            result, list
-        ), f'В качестве ответа должен быть получен list, пришёл {type(result)}'
-        assert len(result) == len(
-            ten_mods
-        ), f'Длина полученного списка должна быть равна {len(ten_mods)}'
+        assert isinstance(result, list), (
+            f'В качестве ответа должен быть получен list, пришёл {type(result)}'
+        )
+        assert len(result) == len(ten_mods), (
+            f'Длина полученного списка должна быть равна {len(ten_mods)}'
+        )
 
     @pytest.mark.skip(reason='Нет возможности протестировать')
     async def test_get_paginated_multiple_staff(
@@ -96,9 +96,9 @@ class TestGetTabitManagement:
                 ),
                 headers=admin_token,
             )
-        assert (
-            response.status_code == status_code
-        ), f'В ответе ожидается status_code {status_code}, получен {response.status_code}'
+        assert response.status_code == status_code, (
+            f'В ответе ожидается status_code {status_code}, получен {response.status_code}'
+        )
 
 
 @pytest.mark.asyncio(loop_scope='session')
@@ -118,9 +118,9 @@ class TestPostTabitManagement:
                 **{'company_id': department.company_id, 'current_department_id': department.id},
             },
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
         result = response.json()
         for key in TabitManagementDataConstants.ADMIN_CREATE_MOD_NEW:
             if key != 'password':
@@ -167,7 +167,7 @@ class TestPostTabitManagement:
             UrlConstants.ADMIN_MODS_URL, headers=admin_token, json=payload
         )
         assert response.status_code == expected_status, (
-            f'В ответе ожидается status_code {expected_status}, ' f'получен {response.status_code}'
+            f'В ответе ожидается status_code {expected_status}, получен {response.status_code}'
         )
         new_user_count = await get_count(async_session, CompanyUser)
         assert new_user_count == old_user_count, (
@@ -203,9 +203,9 @@ class TestUpdateTabitManagement:
             headers=admin_token,
             json=payload,
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
         result = response.json()
         for key in payload:
             assert result[key] == payload[key]
@@ -251,9 +251,9 @@ class TestUpdateTabitManagement:
         )
         moderator = await async_session.merge(moderator)
         new_moderator_data = await update_object(async_session, moderator)
-        assert (
-            new_moderator_data == old_moderator_data
-        ), 'При неуспешном PATCH-запросе объект пользователя не должен меняться'
+        assert new_moderator_data == old_moderator_data, (
+            'При неуспешном PATCH-запросе объект пользователя не должен меняться'
+        )
 
     @pytest.mark.parametrize(
         'payload, check_department_change', TabitManagementDataConstants.ADMIN_PUT_MOD
@@ -278,9 +278,9 @@ class TestUpdateTabitManagement:
             headers=admin_token,
             json=payload,
         )
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        assert response.status_code == status.HTTP_200_OK, (
+            f'В ответе ожидается status_code {status.HTTP_200_OK}, получен {response.status_code}'
+        )
         result = response.json()
         for key in payload:
             if key != 'password':
@@ -327,9 +327,9 @@ class TestUpdateTabitManagement:
         )
         moderator = await async_session.merge(moderator)
         new_moderator_data = await update_object(async_session, moderator)
-        assert (
-            new_moderator_data == old_moderator_data
-        ), 'При неуспешном PUT-запросе объект пользователя не должен меняться'
+        assert new_moderator_data == old_moderator_data, (
+            'При неуспешном PUT-запросе объект пользователя не должен меняться'
+        )
 
     async def test_update_404(self, client: AsyncClient, admin_token):
         """Тест для проверки PATCH- и PUT- запросов к несуществующему пользователю"""


### PR DESCRIPTION
Эндпоинты аутентификации
   - Вход/выход из системы
   - Обновление токенов
   - Получение информации о себе
   - Функционал восстановления и смены паролей

Добавлены методы для работы с паролями: create_password_reset_token, verify_reset_token, reset_password_with_token, reset_password_by_admin, verify_password, change_password
Все методы включают проверку роли модератора (CompanyUserRole.MODERATOR)
Используют существующую JWT стратегию для генерации и проверки токенов

Добавлен новый роутер по пути /{company_slug}/moderator/auth

closes #340 